### PR TITLE
Fix issue where `cleanup-stale-apps` command fails to delete apps with volumesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that are not yet released._
 
+### Fixed
+
+- Fixed issue where `cleanup-stale-apps` command fails to delete apps with volumesets. [PR 175](https://github.com/shakacode/heroku-to-control-plane/pull/175) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [2.0.0] - 2024-05-14
 
 ### BREAKING CHANGES

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -66,7 +66,8 @@ cpl cleanup-images -a $APP_NAME
 
 ### `cleanup-stale-apps`
 
-- Deletes the whole app (GVC with all workloads and all images) for all stale apps
+- Deletes the whole app (GVC with all workloads, all volumesets and all images) for all stale apps
+- Also unbinds the app from the secrets policy, as long as both the identity and the policy exist (and are bound)
 - Stale apps are identified based on the creation date of the latest image
 - Specify the amount of days after an app should be considered stale through `stale_app_image_deployed_days` in the `.controlplane/controlplane.yml` file
 - If `match_if_app_name_starts_with` is `true` in the `.controlplane/controlplane.yml` file, it will delete all stale apps that start with the name

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -32,8 +32,8 @@ describe Command::CleanupStaleApps do
     let!(:app2) { dummy_test_app("with-stale-app-image-deployed-days") }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app1)
-      run_cpl_command!("apply-template", "app", "-a", app2)
+      run_cpl_command!("apply-template", "app", "postgres-with-volume", "-a", app1)
+      run_cpl_command!("apply-template", "app", "postgres-with-volume", "-a", app2)
       run_cpl_command!("build-image", "-a", app1)
       run_cpl_command!("build-image", "-a", app2)
     end
@@ -64,10 +64,12 @@ describe Command::CleanupStaleApps do
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app1}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting app '#{app1}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting image '#{app1}:1'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting image '#{app1}:1' from app '#{app1}'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app2}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting app '#{app2}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting image '#{app2}:1'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting image '#{app2}:1' from app '#{app2}'[.]+? done!/)
     end
 
     it "skips confirmation and deletes stale apps", :slow do
@@ -79,10 +81,12 @@ describe Command::CleanupStaleApps do
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app1}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting app '#{app1}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting image '#{app1}:1'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting image '#{app1}:1' from app '#{app1}'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app2}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting app '#{app2}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting image '#{app2}:1'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting image '#{app2}:1' from app '#{app2}'[.]+? done!/)
     end
   end
 

--- a/spec/command/delete_spec.rb
+++ b/spec/command/delete_spec.rb
@@ -32,8 +32,8 @@ describe Command::Delete do
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to include("No volumesets to delete")
-      expect(result[:stderr]).to include("No images to delete")
+      expect(result[:stderr]).to include("No volumesets to delete from app '#{app}'")
+      expect(result[:stderr]).to include("No images to delete from app '#{app}'")
       expect(result[:stderr]).not_to include("Deleting app")
     end
 
@@ -44,8 +44,8 @@ describe Command::Delete do
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to include("No volumesets to delete")
-      expect(result[:stderr]).to include("No images to delete")
+      expect(result[:stderr]).to include("No volumesets to delete from app '#{app}'")
+      expect(result[:stderr]).to include("No images to delete from app '#{app}'")
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
     end
 
@@ -56,8 +56,8 @@ describe Command::Delete do
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to include("No volumesets to delete")
-      expect(result[:stderr]).to include("No images to delete")
+      expect(result[:stderr]).to include("No volumesets to delete from app '#{app}'")
+      expect(result[:stderr]).to include("No images to delete from app '#{app}'")
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
     end
   end
@@ -81,10 +81,10 @@ describe Command::Delete do
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deleting volumeset 'detached-volume'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting volumeset 'detached-volume' from app '#{app}'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Deleting image '#{app}:1'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting image '#{app}:1' from app '#{app}'[.]+? done!/)
     end
   end
 
@@ -103,7 +103,7 @@ describe Command::Delete do
       result = run_cpl_command("delete", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to include("Workload 'rails' does not exist")
+      expect(result[:stderr]).to include("Workload 'rails' does not exist in app '#{app}'")
     end
   end
 
@@ -135,7 +135,7 @@ describe Command::Delete do
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deleting workload 'rails'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting workload 'rails' from app '#{app}'[.]+? done!/)
     end
 
     it "skips confirmation and deletes workload" do
@@ -145,7 +145,7 @@ describe Command::Delete do
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
-      expect(result[:stderr]).to match(/Deleting workload 'rails'[.]+? done!/)
+      expect(result[:stderr]).to match(/Deleting workload 'rails' from app '#{app}'[.]+? done!/)
     end
   end
 
@@ -223,7 +223,7 @@ describe Command::Delete do
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
-      expect(result[:stderr]).to match(/Unbinding identity from policy[.]+? done!/)
+      expect(result[:stderr]).to match(/Unbinding identity from policy for app '#{app}'[.]+? done!/)
     end
   end
 end


### PR DESCRIPTION
The `cleanup-stale-apps` command is currently outdated compared to the `delete` command, in terms of deleting apps with volumesets.

This PR fixes that by changing the `cleanup-stale-apps` command to simply call the `delete` command for each app, instead of implementing its own delete methods. That ensures that whatever changes are made to the `delete` command are reflected in the `cleanup-stale-apps` command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the `cleanup-stale-apps` command failed to delete apps with volumesets.

- **New Features**
  - Enhanced the `cleanup-stale-apps` command to unbind apps from the secrets policy if both identity and policy exist.
  - Improved error messages and notifications for deleting workloads, volumesets, and images to include application context for better clarity.

- **Documentation**
  - Updated documentation to reflect new functionalities and improved messages for the `cleanup-stale-apps` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->