### PR TITLE
Disable interrupt trap in tests

### DIFF
--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -90,4 +90,11 @@ class Shell
 
     message.gsub(pattern, "XXXXXXX")
   end
+
+  def self.trap_interrupt
+    trap("SIGINT") do
+      puts
+      exit(ExitCode::INTERRUPT)
+    end
+  end
 end

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -267,8 +267,4 @@ module Cpl
   end
 end
 
-# nice Ctrl+C
-trap "INT" do
-  puts
-  exit(ExitCode::INTERRUPT)
-end
+Shell.trap_interrupt unless ENV.fetch("DISABLE_INTERRUPT_TRAP", nil) == "true"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= "test"
 ENV["HIDE_COMMAND_OUTPUT"] = "true"
+ENV["DISABLE_INTERRUPT_TRAP"] = "true"
 
 require "rspec/retry"
 require "simplecov"


### PR DESCRIPTION
Currently, pressing `Ctrl + C` while running the tests does not stop them, because we trap the interrupt signal in the app, which conflicts with RSpec's trap.

This PR adds a new flag `DISABLE_INTERRUPT_TRAP` to prevent trapping the interrupt signal, which we can use in the tests to make sure that `Ctrl + C` works properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to handle interrupt signals more gracefully, ensuring a smoother exit process.
  
- **Bug Fixes**
  - Improved interrupt handling to prevent abrupt terminations during operations.

- **Tests**
  - Added a new environment variable setting for testing interrupt handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->