### PR TITLE
Automatically create identity (if not exists) in `setup-app` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ _Please add entries here for your pull requests that have not yet been released.
 ### Changed
 
 - `cpl` now sets `CPLN_SKIP_UPDATE_CHECK` to `true` for all internal `cpln` calls, which disables the version check and prevents cluttering the logs. [PR 180](https://github.com/shakacode/control-plane-flow/pull/180) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-- `setup-app` command now automatically creates a secret and policy for the app if they do not exist. The `--skip-secret-access-binding` option prevents this behavior. [PR 181](https://github.com/shakacode/control-plane-flow/pull/181) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `setup-app` command now automatically creates a secret, policy, and identity for the app if they do not exist. The `--skip-secrets-setup` option prevents this behavior. [PR 181](https://github.com/shakacode/control-plane-flow/pull/181) by [Rafael Gomes](https://github.com/rafaelgomesxyz). [PR 190](https://github.com/shakacode/control-plane-flow/pull/190) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Specific validations are now run before commands, and the command will exit with a non-zero code if any validation fails. Can be disabled by setting `DISABLE_VALIDATIONS` env var to `true`. [PR 185](https://github.com/shakacode/control-plane-flow/pull/185) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Deprecated the `--skip-secret-access-binding` option in favor of `--skip-secrets-setup`. This can also now be configured through `skip_secrets_setup` in `controlplane.yml` [PR 190](https://github.com/shakacode/control-plane-flow/pull/190) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [2.0.2] - 2024-05-17
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ aliases:
       - rails
       - sidekiq
 
+    # Skips secrets setup when running `cpl setup-app`.
+    skip_secrets_setup: true
+
     # Only needed if using a custom secrets name.
     # The default is '{APP_PREFIX}-secrets'. For example:
     # - for an app 'my-app-staging' with `match_if_app_name_starts_with` set to `false`,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -429,7 +429,7 @@ cpl run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:mig
 - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
   using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
 - Creates identity for secrets if it does not exist
-- Use `--skip-secret-access-binding` to prevent the automatic setup of secrets
+- Use `--skip-secrets-setup` to prevent the automatic setup of secrets
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -429,7 +429,8 @@ cpl run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:mig
 - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
   using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
 - Creates identity for secrets if it does not exist
-- Use `--skip-secrets-setup` to prevent the automatic setup of secrets
+- Use `--skip-secrets-setup` to prevent the automatic setup of secrets,
+  or set it through `skip_secrets_setup` in the `.controlplane/controlplane.yml` file
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -428,6 +428,7 @@ cpl run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:mig
 - This should only be used for temporary apps like review apps, never for persistent apps like production or staging (to update workloads for those, use 'cpl apply-template' instead)
 - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
   using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
+- Creates identity for secrets if it does not exist
 - Use `--skip-secret-access-binding` to prevent the automatic setup of secrets
 - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
 - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -1,0 +1,42 @@
+# Secrets and ENV Values
+
+You can store ENV values used by a container (within a workload) within Control Plane at the following levels:
+
+1. Workload Container
+2. GVC
+
+For your "review apps," it is convenient to have simple ENVs stored in plain text in your source code. You will want to
+keep some ENVs, like the Rails' `SECRET_KEY_BASE`, out of your source code. For staging and production apps, you will
+set these values directly at the GVC or workload levels, so none of these ENV values are committed to the source code.
+
+For storing ENVs in the source code, we can use a level of indirection so that you can store an ENV value in your source
+code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then have the secret value stored at the org
+level, which applies to your GVCs mapped to that org.
+
+For setting up secrets, you'll need:
+
+- **Org-level Secret:** This is where the values will be stored.
+- **GVC Identity:** An identity that must be associated with each workload that requires access to the secret.
+- **Org-level Policy:** A policy that binds the identity to the secret, granting the necessary permissions for the workload to access the secret.
+
+You can do this during the initial app setup, like this:
+
+1. Add the template for `app` to `.controlplane/templates`
+2. Ensure that the `app` template is listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
+3. Run `cpl setup-app -a $APP_NAME`
+4. The secrets, secrets policy and identity will be automatically created, along with the proper binding
+5. In the Control Plane console, upper left "Manage Org" menu, click on "Secrets"
+6. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there
+7. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/$APP_PREFIX-secrets.SOME_VAR`)
+
+Here are the manual steps for reference. We recommend that you follow the steps above:
+
+1. In the upper left of the Control Plane console, "Manage Org" menu, click on "Secrets"
+2. Create a secret with `Secret Type: Dictionary` (e.g., `my-secrets`) and add the secret env vars there
+3. In the upper left "Manage GVC" menu, click on "Identities"
+4. Create an identity (e.g., `my-identity`)
+5. Navigate to the workload that you want to associate with the identity created
+6. Click "Identity" on the left menu and select the identity created
+7. In the lower left "Access Control" menu, click on "Policies"
+8. Create a policy with `Target Kind: Secret` and add a binding with the `reveal` permission for the identity created
+9. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/my-secrets.SOME_VAR`)

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -88,13 +88,12 @@ level, which applies to your GVCs mapped to that org.
 You can do this during the initial app setup, like this:
 
 1. Add the template for `app` to `.controlplane/templates`
-2. Ensure that the `app` template includes the `identity`
-3. Ensure that the `app` template is listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
-4. Run `cpl setup-app -a $APP_NAME`
-5. The secrets, secrets policy and identity will be automatically created, along with the proper binding
-6. In the Control Plane console, upper left "Manage Org" menu, click on "Secrets"
-7. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there
-8. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/$APP_PREFIX-secrets.SOME_VAR`)
+2. Ensure that the `app` template is listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
+3. Run `cpl setup-app -a $APP_NAME`
+4. The secrets, secrets policy and identity will be automatically created, along with the proper binding
+5. In the Control Plane console, upper left "Manage Org" menu, click on "Secrets"
+6. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there
+7. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/$APP_PREFIX-secrets.SOME_VAR`)
 
 Here are the manual steps for reference. We recommend that you follow the steps above:
 

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -3,7 +3,7 @@
 1. [GVCs vs. Orgs](#gvcs-vs-orgs)
 2. [RAM](#ram)
 3. [Remote IP](#remote-ip)
-4. [ENV Values](#env-values)
+4. [Secrets and ENV Values](/docs/secrets-and-env-values.md)
 5. [CI](#ci)
 6. [Memcached](#memcached)
 7. [Sidekiq](#sidekiq)
@@ -69,43 +69,6 @@ https://shakadocs.controlplane.com/concepts/security#headers). On Rails, the `Ac
 pick those up and automatically populate `request.remote_ip`.
 
 So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
-
-## ENV Values
-
-You can store ENV values used by a container (within a workload) within Control Plane at the following levels:
-
-1. Workload Container
-2. GVC
-
-For your "review apps," it is convenient to have simple ENVs stored in plain text in your source code. You will want to
-keep some ENVs, like the Rails' `SECRET_KEY_BASE`, out of your source code. For staging and production apps, you will
-set these values directly at the GVC or workload levels, so none of these ENV values are committed to the source code.
-
-For storing ENVs in the source code, we can use a level of indirection so that you can store an ENV value in your source
-code like `cpln://secret/my-app-review-env-secrets.SECRET_KEY_BASE` and then have the secret value stored at the org
-level, which applies to your GVCs mapped to that org.
-
-You can do this during the initial app setup, like this:
-
-1. Add the template for `app` to `.controlplane/templates`
-2. Ensure that the `app` template is listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
-3. Run `cpl setup-app -a $APP_NAME`
-4. The secrets, secrets policy and identity will be automatically created, along with the proper binding
-5. In the Control Plane console, upper left "Manage Org" menu, click on "Secrets"
-6. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there
-7. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/$APP_PREFIX-secrets.SOME_VAR`)
-
-Here are the manual steps for reference. We recommend that you follow the steps above:
-
-1. In the upper left of the Control Plane console, "Manage Org" menu, click on "Secrets"
-2. Create a secret with `Secret Type: Dictionary` (e.g., `my-secrets`) and add the secret env vars there
-3. In the upper left "Manage GVC" menu, click on "Identities"
-4. Create an identity (e.g., `my-identity`)
-5. Navigate to the workload that you want to associate with the identity created
-6. Click "Identity" on the left menu and select the identity created
-7. In the lower left "Access Control" menu, click on "Policies"
-8. Create a policy with `Target Kind: Secret` and add a binding with the `reveal` permission for the identity created
-9. Use `cpln://secret/...` in the app to access the secret env vars (e.g., `cpln://secret/my-secrets.SOME_VAR`)
 
 ## CI
 

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -39,6 +39,9 @@ aliases:
       - rails
       - sidekiq
 
+    # Skips secrets setup when running `cpl setup-app`.
+    skip_secrets_setup: true
+
     # Only needed if using a custom secrets name.
     # The default is '{APP_PREFIX}-secrets'. For example:
     # - for an app 'my-app-staging' with `match_if_app_name_starts_with` set to `false`,

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -39,8 +39,8 @@ aliases:
       - rails
       - sidekiq
 
-    # Skips secrets setup when running `cpl setup-app`.
-    skip_secrets_setup: true
+    # Uncomment next line to skips secrets setup when running `cpl setup-app`.
+    # skip_secrets_setup: true
 
     # Only needed if using a custom secrets name.
     # The default is '{APP_PREFIX}-secrets'. For example:

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -273,8 +273,20 @@ module Command
     def self.skip_secret_access_binding_option(required: false)
       {
         name: :skip_secret_access_binding,
+        new_name: :skip_secrets_setup,
         params: {
           desc: "Skips secret access binding",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
+
+    def self.skip_secrets_setup_option(required: false)
+      {
+        name: :skip_secrets_setup,
+        params: {
+          desc: "Skips secrets setup",
           type: :boolean,
           required: required
         }

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -419,6 +419,17 @@ module Command
         }
       }
     end
+
+    def self.add_app_identity_option(required: false)
+      {
+        name: :add_app_identity,
+        params: {
+          desc: "Adds app identity template if it does not exist",
+          type: :boolean,
+          required: required
+        }
+      }
+    end
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -17,14 +17,15 @@ module Command
       - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
         using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
       - Creates identity for secrets if it does not exist
-      - Use `--skip-secrets-setup` to prevent the automatic setup of secrets
+      - Use `--skip-secrets-setup` to prevent the automatic setup of secrets,
+        or set it through `skip_secrets_setup` in the `.controlplane/controlplane.yml` file
       - Runs a post-creation hook after the app is created if `hooks.post_creation` is specified in the `.controlplane/controlplane.yml` file
       - If the hook exits with a non-zero code, the command will stop executing and also exit with a non-zero code
       - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
     DESC
     VALIDATIONS = %w[config templates].freeze
 
-    def call # rubocop:disable Metrics/MethodLength
+    def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       templates = config[:setup_app_templates]
 
       app = cp.fetch_gvc
@@ -35,7 +36,7 @@ module Command
       end
 
       skip_secrets_setup = config.options[:skip_secret_access_binding] ||
-                           config.options[:skip_secrets_setup]
+                           config.options[:skip_secrets_setup] || config.current[:skip_secrets_setup]
 
       create_secret_and_policy_if_not_exist unless skip_secrets_setup
 

--- a/lib/core/helpers.rb
+++ b/lib/core/helpers.rb
@@ -3,6 +3,8 @@
 require "securerandom"
 
 module Helpers
+  module_function
+
   def strip_str_and_validate(str)
     return str if str.nil?
 
@@ -12,5 +14,13 @@ module Helpers
 
   def random_four_digits
     SecureRandom.random_number(1000..9999)
+  end
+
+  def normalize_command_name(name)
+    name.to_s.tr("_", "-")
+  end
+
+  def normalize_option_name(name)
+    "--#{name.to_s.tr('_', '-')}"
   end
 end

--- a/spec/command/delete_spec.rb
+++ b/spec/command/delete_spec.rb
@@ -153,7 +153,7 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("nonexistent-identity") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secret-access-binding")
+      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do
@@ -172,7 +172,7 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("nonexistent-policy") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secret-access-binding")
+      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do
@@ -191,7 +191,7 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("secrets") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secret-access-binding")
+      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do

--- a/spec/command/doctor_spec.rb
+++ b/spec/command/doctor_spec.rb
@@ -82,7 +82,7 @@ describe Command::Doctor do
       result = run_cpl_command("doctor", "--validations", "unknown")
 
       expect(result[:status]).not_to eq(0)
-      expect(result[:stderr]).to include("Invalid value provided for option 'validations'")
+      expect(result[:stderr]).to include("Invalid value provided for option --validations")
     end
   end
 

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -25,7 +25,7 @@ describe Command::SetupApp do
     end
   end
 
-  context "when skipping secret access binding" do
+  context "when skipping secrets setup" do
     let!(:app) { dummy_test_app }
 
     after do
@@ -33,7 +33,7 @@ describe Command::SetupApp do
     end
 
     it "applies templates from 'setup_app_templates'" do
-      result = run_cpl_command("setup-app", "-a", app, "--skip-secret-access-binding")
+      result = run_cpl_command("setup-app", "-a", app, "--skip-secrets-setup")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Created items")
@@ -42,6 +42,15 @@ describe Command::SetupApp do
       expect(result[:stderr]).to include("[workload] rails")
       expect(result[:stderr]).to include("[workload] postgres")
       expect(result[:stderr]).not_to include("Failed to apply templates")
+      expect(result[:stderr]).not_to include("Binding identity")
+    end
+
+    it "works with deprecated --skip-secret-access-binding name" do
+      result = run_cpl_command("setup-app", "-a", app, "--skip-secret-access-binding")
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("DEPRECATED: Option --skip-secret-access-binding is deprecated")
+      expect(result[:stderr]).not_to include("Binding identity")
     end
   end
 

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -76,27 +76,11 @@ describe Command::SetupApp do
       run_cpl_command!("delete", "-a", app, "--yes")
     end
 
-    it "raises error" do
-      result = run_cpl_command("setup-app", "-a", app)
-
-      expect(result[:status]).not_to eq(0)
-      expect(result[:stderr]).to include("Secret 'dummy-test-secrets' already exists")
-      expect(result[:stderr]).to include("Policy 'dummy-test-secrets-policy' already exists")
-      expect(result[:stderr]).to include("Can't bind identity to policy")
-    end
-  end
-
-  context "when identity exists" do
-    let!(:app) { dummy_test_app("secrets") }
-
-    after do
-      run_cpl_command!("delete", "-a", app, "--yes")
-    end
-
-    it "binds identity to policy" do
+    it "creates identity, and binds identity to policy" do
       result = run_cpl_command("setup-app", "-a", app)
 
       expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("[identity] #{app}-identity")
       expect(result[:stderr]).to include("Secret 'dummy-test-secrets' already exists")
       expect(result[:stderr]).to include("Policy 'dummy-test-secrets-policy' already exists")
       expect(result[:stderr])

--- a/spec/cpl_spec.rb
+++ b/spec/cpl_spec.rb
@@ -16,7 +16,7 @@ describe Cpl do
       result = run_cpl_command("test", option_key_name)
 
       expect(result[:status]).not_to eq(0)
-      expect(result[:stderr]).to include("No value provided for option '#{option[:name]}'")
+      expect(result[:stderr]).to include("No value provided for option --#{option[:name].to_s.tr('_', '-')}")
     end
   end
 end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -138,7 +138,7 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
 
     puts "\nCreating app '#{app}' for tests\n\n" if ENV.fetch("VERBOSE_TESTS", nil) == "true"
 
-    run_cpl_command!("setup-app", "-a", app, "--skip-secret-access-binding")
+    run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
 
     image_before_deploy_count.times do
       run_cpl_command!("build-image", "-a", app)

--- a/templates/app.yml
+++ b/templates/app.yml
@@ -11,8 +11,3 @@ spec:
   staticPlacement:
     locationLinks:
       - {{APP_LOCATION_LINK}}
----
-# Identity is needed to access secrets
-kind: identity
-name: {{APP_IDENTITY}}
-


### PR DESCRIPTION
Fixes #186
Fixes #187
Fixes #189

To simplify the process of setting up secrets, the identity is now automatically created in the `setup-app` command if it's not in the `app` template.

Also:

- Deprecated the `--skip-secret-access-binding` option in favor of `--skip-secrets-setup`
- Added some logic to warn about deprecated options
- Added a  `skip_secrets_setup` option to the `.controlplane/controlplane.yml` file.

Finally, moved the "ENV Values" section from `tips.md` to a separate `secrets-and-env-values.md` file, and added an explanation of the relationship between secrets, secrets policy, and identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `skip_secrets_setup` configuration option to skip secrets setup during app setup.
  - Added detailed documentation on managing secrets and ENV values.

- **Documentation**
  - Updated documentation to reflect changes in secrets setup and added new file `secrets-and-env-values.md`.
  - Renamed section in `tips.md` from "ENV Values" to "Secrets and ENV Values".

- **Refactor**
  - Modified command options and updated logic to handle new `skip_secrets_setup` option.

- **Tests**
  - Updated test cases to reflect changes in command options and added tests for deprecated options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->