### PR TITLE
Add timeout for runner jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Added
+
+- Added a timeout for `run` jobs (6 hours by default, but configurable through `runner_job_timeout` in `controlplane.yml`). [PR 194](https://github.com/shakacode/control-plane-flow/pull/194) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Changed
 
 - `run` command now overrides the `--image`, `--cpu`, and `--memory` for each job separately, which completely removes any race conditions when running simultaneous jobs with different overrides. [PR 182](https://github.com/shakacode/control-plane-flow/pull/182) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ aliases:
     # If not specified, defaults to "2Gi" (2 gibibytes).
     runner_job_default_memory: "4Gi"
 
+    # Sets the maximum number of seconds that `cpl run` jobs can execute before being stopped.
+    # If not specified, defaults to 21600 (6 hours).
+    runner_job_timeout: 1000
+
     # Apps with a deployed image created before this amount of days will be listed for deletion
     # when running the command `cpl cleanup-stale-apps`.
     stale_app_image_deployed_days: 5

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -380,6 +380,8 @@ cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
 - By default, all jobs use a CPU size of 1 (1 core) and a memory size of 2Gi (2 gibibytes)
   (can be configured through `runner_job_default_cpu` and `runner_job_default_memory` in `controlplane.yml`,
   and also overridden per job through `--cpu` and `--memory`)
+- By default, the job is stopped if it takes longer than 6 hours to finish
+  (can be configured though `runner_job_timeout` in `controlplane.yml`)
 
 ```sh
 # Opens shell (bash by default).

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -92,6 +92,10 @@ aliases:
     # If not specified, defaults to "2Gi" (2 gibibytes).
     runner_job_default_memory: "4Gi"
 
+    # Sets the maximum number of seconds that `cpl run` jobs can execute before being stopped.
+    # If not specified, defaults to 21600 (6 hours).
+    runner_job_timeout: 1000
+
     # Apps with a deployed image created before this amount of days will be listed for deletion
     # when running the command `cpl cleanup-stale-apps`.
     stale_app_image_deployed_days: 5

--- a/spec/dummy/.controlplane/controlplane.yml
+++ b/spec/dummy/.controlplane/controlplane.yml
@@ -143,6 +143,12 @@ apps:
     match_if_app_name_starts_with: true
     fix_terminal_size: true
 
+  dummy-test-runner-job-timeout-{GLOBAL_IDENTIFIER}:
+    <<: *common
+
+    match_if_app_name_starts_with: true
+    runner_job_timeout: 10
+
   dummy-test-nonexistent-identity-{GLOBAL_IDENTIFIER}:
     <<: *common
 


### PR DESCRIPTION
Fixes #193 

Adds a timeout for runner jobs (6 hours by default, but configurable through `runner_job_timeout` in `controlplane.yml`), to prevent issues where an interactive job may not finish properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable timeout feature for `run` jobs, with a default value of 1000 seconds, set via `runner_job_timeout` in `controlplane.yml`.
  - Added default job timeout of 6 hours and a job history limit of 10 for `run` commands.
  
- **Documentation**
  - Updated documentation to reflect the new `runner_job_timeout` parameter and default job timeout settings.

- **Tests**
  - Adjusted test scenarios to incorporate the new job timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->