### PR TITLE
Fix issue where `ps:wait` command hangs forever if workloads are suspended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Fixed
+
+- Fixed issue where `ps:wait` command hangs forever if workloads are suspended. [PR 198](https://github.com/shakacode/control-plane-flow/pull/198) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ### Added
 
 - Added a timeout for `run` jobs (6 hours by default, but configurable through `runner_job_timeout` in `controlplane.yml`). [PR 194](https://github.com/shakacode/control-plane-flow/pull/194) by [Rafael Gomes](https://github.com/rafaelgomesxyz).

--- a/lib/command/ps_wait.rb
+++ b/lib/command/ps_wait.rb
@@ -22,13 +22,17 @@ module Command
       ```
     EX
 
-    def call
+    def call # rubocop:disable Metrics/MethodLength
       @workloads = [config.options[:workload]] if config.options[:workload]
       @workloads ||= config[:app_workloads] + config[:additional_workloads]
 
       @workloads.reverse_each do |workload|
-        step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
-          cp.workload_deployments_ready?(workload, location: config.location, expected_status: true)
+        if cp.workload_suspended?(workload)
+          progress.puts("Workload '#{workload}' is suspended. Skipping...")
+        else
+          step("Waiting for workload '#{workload}' to be ready", retry_on_failure: true) do
+            cp.workload_deployments_ready?(workload, location: config.location, expected_status: true)
+          end
         end
       end
     end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -256,6 +256,11 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.update_workload(org: org, gvc: gvc, workload: workload, data: data)
   end
 
+  def workload_suspended?(workload)
+    details = fetch_workload!(workload)
+    details["spec"]["defaultOptions"]["suspend"]
+  end
+
   def workload_force_redeployment(workload)
     cmd = "cpln workload force-redeployment #{workload} #{gvc_org}"
     perform!(cmd)

--- a/spec/command/ps_wait_spec.rb
+++ b/spec/command/ps_wait_spec.rb
@@ -10,19 +10,35 @@ describe Command::PsWait do
     run_cpl_command!("ps:restart", "-a", app)
   end
 
-  it "waits for all workloads to be ready", :slow do
-    result = run_cpl_command("ps:wait", "-a", app)
+  context "when no workloads are suspended" do
+    it "waits for all workloads to be ready", :slow do
+      result = run_cpl_command("ps:wait", "-a", app)
 
-    expect(result[:status]).to eq(0)
-    expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
-    expect(result[:stderr]).to match(/Waiting for workload 'postgres' to be ready[.]+? done!/)
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
+      expect(result[:stderr]).to match(/Waiting for workload 'postgres' to be ready[.]+? done!/)
+    end
+
+    it "waits for specific workload to be ready", :slow do
+      result = run_cpl_command("ps:wait", "-a", app, "--workload", "rails")
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
+      expect(result[:stderr]).not_to include("postgres")
+    end
   end
 
-  it "waits for specific workload to be ready", :slow do
-    result = run_cpl_command("ps:wait", "-a", app, "--workload", "rails")
+  context "when some workloads are suspended" do
+    before do
+      run_cpl_command!("ps:stop", "-a", app, "--workload", "rails")
+    end
 
-    expect(result[:status]).to eq(0)
-    expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
-    expect(result[:stderr]).not_to include("postgres")
+    it "skips suspended workloads", :slow do
+      result = run_cpl_command("ps:wait", "-a", app)
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("Workload 'rails' is suspended")
+      expect(result[:stderr]).to match(/Waiting for workload 'postgres' to be ready[.]+? done!/)
+    end
   end
 end


### PR DESCRIPTION
Fixes #197

The `ps:wait` command hangs forever if workloads are suspended. This PR fixes that by printing a message when a workload is suspended and skipping it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to check if a workload is suspended before waiting for workload readiness.

- **Bug Fixes**
  - Fixed an issue where the `ps:wait` command would hang indefinitely if workloads were suspended.

- **Tests**
  - Added new test cases to handle scenarios where workloads are suspended or not suspended.

- **Documentation**
  - Updated CHANGELOG to reflect the bug fix and new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->