### PR TITLE
Fix wrong logic for getting latest image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Fixed
+
+- Fixed issue where latest image may be incorrect. [PR 201](https://github.com/shakacode/control-plane-flow/pull/201) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Fixed issue where `build-image` command hangs forever waiting for image to be available. [PR 201](https://github.com/shakacode/control-plane-flow/pull/201) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [2.2.0] - 2024-06-07
 
 ### Fixed

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -41,7 +41,8 @@ module Command
       progress.puts("\nPushed image to '/org/#{config.org}/image/#{image_name}'.\n\n")
 
       step("Waiting for image to be available", retry_on_failure: true) do
-        image_name == cp.latest_image(refresh: true)
+        images = cp.query_images["items"]
+        images.find { |image| image["name"] == image_name }
       end
     end
   end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -69,7 +69,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     if matching_items.empty?
       name_only ? "#{app_name}:#{NO_IMAGE_AVAILABLE}" : nil
     else
-      latest_item = matching_items.max_by { |item| extract_image_number(item["name"]) }
+      latest_item = matching_items.max_by { |item| DateTime.parse(item["created"]) }
       name_only ? latest_item["name"] : latest_item
     end
   end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -39,9 +39,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
   # image
 
-  def latest_image(a_gvc = gvc, a_org = org, refresh: false)
+  def latest_image(a_gvc = gvc, a_org = org)
     @latest_image ||= {}
-    @latest_image[a_gvc] = nil if refresh
     @latest_image[a_gvc] ||=
       begin
         items = query_images(a_gvc, a_org)["items"]

--- a/spec/command/cleanup_images_spec.rb
+++ b/spec/command/cleanup_images_spec.rb
@@ -158,7 +158,7 @@ describe Command::CleanupImages do
   end
 
   context "with multiple apps" do
-    let!(:app_prefix) { dummy_test_app_prefix("with-image-retention") }
+    let!(:app_prefix) { dummy_test_app_prefix("image-retention") }
     let!(:app1) { dummy_test_app("image-retention", "1", create_if_not_exists: true) }
     let!(:app2) { dummy_test_app("image-retention", "2", create_if_not_exists: true) }
 

--- a/spec/command/run_spec.rb
+++ b/spec/command/run_spec.rb
@@ -256,7 +256,7 @@ describe Command::Run do
         run_cpl_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
       end
 
-      it "updates runner workload" do
+      it "updates runner workload", :slow do
         result = nil
 
         spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
@@ -279,7 +279,7 @@ describe Command::Run do
         run_cpl_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
       end
 
-      it "updates runner workload" do
+      it "updates runner workload", :slow do
         result = nil
 
         spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|


### PR DESCRIPTION
Fixes #200 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected issues with retrieving the latest image, ensuring more accurate results.
  - Fixed hang issue with the `build-image` command.

- **Documentation**
  - Updated `CHANGELOG.md` to reflect recent fixes related to image retrieval and `build-image` command performance.

- **Tests**
  - Adjusted test configurations for better accuracy and performance.
  - Added a `:slow` tag to specific test cases to improve test suite organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->