### PR TITLE
Rename the CLI from `cpl` to `cpflow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ _Please add entries here for your pull requests that have not yet been released.
 
 ### Changed
 
-- `cpl` now sets `CPLN_SKIP_UPDATE_CHECK` to `true` for all internal `cpln` calls, which disables the version check and prevents cluttering the logs. [PR 180](https://github.com/shakacode/control-plane-flow/pull/180) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- `cpflow` now sets `CPLN_SKIP_UPDATE_CHECK` to `true` for all internal `cpln` calls, which disables the version check and prevents cluttering the logs. [PR 180](https://github.com/shakacode/control-plane-flow/pull/180) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - `setup-app` command now automatically creates a secret, policy, and identity for the app if they do not exist. The `--skip-secrets-setup` option prevents this behavior. [PR 181](https://github.com/shakacode/control-plane-flow/pull/181) by [Rafael Gomes](https://github.com/rafaelgomesxyz). [PR 190](https://github.com/shakacode/control-plane-flow/pull/190) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Specific validations are now run before commands, and the command will exit with a non-zero code if any validation fails. Can be disabled by setting `DISABLE_VALIDATIONS` env var to `true`. [PR 185](https://github.com/shakacode/control-plane-flow/pull/185) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Deprecated the `--skip-secret-access-binding` option in favor of `--skip-secrets-setup`. This can also now be configured through `skip_secrets_setup` in `controlplane.yml` [PR 190](https://github.com/shakacode/control-plane-flow/pull/190) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
@@ -139,7 +139,7 @@ _Please add entries here for your pull requests that have not yet been released.
 ### Fixed
 
 - Fixed issue where `info` command does not respect `CPLN_ORG` env var. [PR 88](https://github.com/shakacode/control-plane-flow/pull/88) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-- Fixed issues with running `cpl --version` and `cpl --help` where no configuration file exists. [PR 100](https://github.com/shakacode/control-plane-flow/pull/100) by [Mostafa Ahangarha](https://github.com/ahangarha).
+- Fixed issues with running `cpflow --version` and `cpflow --help` where no configuration file exists. [PR 100](https://github.com/shakacode/control-plane-flow/pull/100) by [Mostafa Ahangarha](https://github.com/ahangarha).
 - Fixed issue where `delete` command fails to delete apps with volumesets. [PR 123](https://github.com/shakacode/control-plane-flow/pull/123) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ### Added
@@ -172,7 +172,7 @@ _Please add entries here for your pull requests that have not yet been released.
 
 ### Changed
 
-- Calling `cpl` with no command now shows the help menu. [PR 83](https://github.com/shakacode/control-plane-flow/pull/83) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+- Calling `cpflow` with no command now shows the help menu. [PR 83](https://github.com/shakacode/control-plane-flow/pull/83) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [1.1.1] - 2023-09-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@
 
 ## Installation
 
-Rather than installing `cpl` as a Ruby gem, install this repo locally and alias the `cpl` command globally for easier
+Rather than installing `cpflow` as a Ruby gem, install this repo locally and alias the `cpflow` command globally for easier
 access, e.g.:
 
 ```sh
 git clone https://github.com/shakacode/control-plane-flow
 
 # Create an alias in some local shell startup script, e.g., `.profile`, `.bashrc`, etc.
-alias cpl="~/projects/control-plane-flow/bin/cpl"
+alias cpflow="~/projects/control-plane-flow/bin/cpflow"
 ```
 
 ## Linting
@@ -64,10 +64,10 @@ CPLN_ORG=your-org-for-tests bundle exec rspec --tag slow
 2. Use the `--trace` option to see full logging of HTTP requests. Warning, this will display keys to your logs or console.
 1. Add a breakpoint (`debugger`) to any line of code you want to debug.
 2. Modify the `lib/command/test.rb` file to trigger the code you want to test. To simulate a command, you can use
-   `Cpl::Cli.start` (e.g., `Cpl::Cli.start(["deploy-image", "-a", "my-app-name"])` would be the same as running
-   `cpl deploy-image -a my-app-name`).
+   `Cpflow::Cli.start` (e.g., `Cpflow::Cli.start(["deploy-image", "-a", "my-app-name"])` would be the same as running
+   `cpflow deploy-image -a my-app-name`).
 3. Run the `test` command in your test app with a `.controlplane` directory.
 
 ```sh
-cpl test
+cpflow test
 ```

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cpflow (2.2.2)
+    cpflow (2.2.4)
       debug (~> 1.7.1)
       dotenv (~> 2.8.1)
       jwt (~> 2.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cpl (2.2.4)
+    cpflow (2.2.2)
       debug (~> 1.7.1)
       dotenv (~> 2.8.1)
       jwt (~> 2.8.1)
@@ -110,7 +110,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  cpl!
+  cpflow!
   overcommit (~> 0.60.0)
   rake (~> 13.0)
   rspec (~> 3.12.0)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The power of Kubernetes with the ease of Heroku!
 
 <meta name="author" content="Justin Gordon and Sergey Tarasov">
-<meta name="description" content="Instructions on how to migrate from Heroku to Control Plane and a CLI called cpl to make it easier.">
+<meta name="description" content="Instructions on how to migrate from Heroku to Control Plane and a CLI called cpflow to make it easier.">
 <meta name="copyright" content="ShakaCode, 2023">
 <meta name="keywords" content="Control Plane, Heroku, Kubernetes, K8, Infrastructure">
 <meta name="google-site-verification" content="dIV4nMplcYl6YOKOaZMqgvdKXhLJ4cdYY6pS6e_YrPU" />
@@ -9,10 +9,10 @@
 [![RSpec](https://github.com/shakacode/control-plane-flow/actions/workflows/rspec.yml/badge.svg)](https://github.com/shakacode/control-plane-flow/actions/workflows/rspec.yml)
 [![Rubocop](https://github.com/shakacode/control-plane-flow/actions/workflows/rubocop.yml/badge.svg)](https://github.com/shakacode/control-plane-flow/actions/workflows/rubocop.yml)
 
-[![Gem](https://badge.fury.io/rb/cpl.svg)](https://badge.fury.io/rb/cpl)
+[![Gem](https://badge.fury.io/rb/cpflow.svg)](https://badge.fury.io/rb/cpflow)
 
 
-Here's a playbook for migrating from [Heroku Flow](https://www.heroku.com/flow) to [Control Plane](https://shakacode.controlplane.com) with our `cpl` gem source code.
+Here's a playbook for migrating from [Heroku Flow](https://www.heroku.com/flow) to [Control Plane](https://shakacode.controlplane.com) with our `cpflow` gem source code.
 
 ----
 
@@ -22,12 +22,12 @@ _If you need a free demo account for Control Plane (no CC required), you can con
 
 Be sure to see the [demo app](https://github.com/shakacode/react-webpack-rails-tutorial/tree/master/.controlplane)
 If you would like to see the simple YAML configuration and setup,
-Also, check [how the `cpl` gem (this project) is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
+Also, check [how the `cpflow` gem (this project) is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
 Here is a brief [video overview](https://www.youtube.com/watch?v=llaQoAV_6Iw).
 
 ---
 
-This playbook shows how to move "Heroku apps" to "Control Plane workloads" via an open-source `cpl` CLI on top of
+This playbook shows how to move "Heroku apps" to "Control Plane workloads" via an open-source `cpflow` CLI on top of
 Control Plane's `cpln` CLI.
 
 Heroku provides a UX and CLI that enables easy publishing of Ruby on Rails and other apps. This ease of use comes via
@@ -50,7 +50,7 @@ a **helper CLI** based on templates to save lots of day-to-day typing (and human
 9. [In-memory Databases](#in-memory-databases)
 10. [Scheduled Jobs](#scheduled-jobs)
 11. [CLI Commands Reference](#cli-commands-reference)
-12. [Mapping of Heroku Commands to `cpl` and `cpln`](#mapping-of-heroku-commands-to-cpl-and-cpln)
+12. [Mapping of Heroku Commands to `cpflow` and `cpln`](#mapping-of-heroku-commands-to-cpflow-and-cpln)
 13. [Examples](#examples)
 14. [Migrating Postgres Database from Heroku Infrastructure](/docs/postgres.md)
 15. [Migrating Redis Database from Heroku Infrastructure](/docs/redis.md)
@@ -58,7 +58,7 @@ a **helper CLI** based on templates to save lots of day-to-day typing (and human
 
 ## Key Features
 
-- A `cpl` command to complement the default Control Plane `cpln` command with "Heroku style scripting." The Ruby source
+- A `cpflow` command to complement the default Control Plane `cpln` command with "Heroku style scripting." The Ruby source
   can serve as inspiration for your own scripts.
 - Easy to understand Heroku to Control Plane conventions in setup and naming.
 - **Safe, production-ready** equivalents of `heroku run` and `heroku run:detached` for Control Plane.
@@ -125,11 +125,11 @@ npm update -g @controlplane/cli
 
 5. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
 
-6. Install Heroku to Control Plane `cpl` CLI as a [Ruby gem](https://rubygems.org/gems/cpl): `gem install cpl`. If you want to use `cpl` from Rake tasks in a Rails project, use `Bundler.with_unbundled_env { `cpl help` } or else you'll get an error that `cpl` cannot be found. While you can add `cpl` to your Gemfile, it's not recommended because it might trigger conflicts with other gems.
+6. Install Heroku to Control Plane `cpflow` CLI as a [Ruby gem](https://rubygems.org/gems/cpflow): `gem install cpflow`. If you want to use `cpflow` from Rake tasks in a Rails project, use `Bundler.with_unbundled_env { `cpflow help` } or else you'll get an error that `cpflow` cannot be found. While you can add `cpflow` to your Gemfile, it's not recommended because it might trigger conflicts with other gems.
 
 7. You can use [this Dockerfile](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/Dockerfile) as an example for your project. Ensure that you have Docker running.
 
-**Note:** Do not confuse the `cpl` CLI with the `cpln` CLI. The `cpl` CLI is the Heroku to Control Plane playbook CLI.
+**Note:** Do not confuse the `cpflow` CLI with the `cpln` CLI. The `cpflow` CLI is the Heroku to Control Plane playbook CLI.
 The `cpln` CLI is the Control Plane CLI.
 
 ## Steps to Migrate
@@ -138,7 +138,7 @@ Click [here](/docs/migrating.md) to see the steps to migrate.
 
 ## Configuration Files
 
-The `cpl` gem is based on several configuration files within a `/.controlplane` top-level directory in your project.
+The `cpflow` gem is based on several configuration files within a `/.controlplane` top-level directory in your project.
 
 ```
 .controlplane/
@@ -166,7 +166,7 @@ Here's a complete example of all supported config keys explained for the `contro
 ```yaml
 # Keys beginning with "cpln_" correspond to your settings in Control Plane.
 
-# Global settings that apply to `cpl` usage.
+# Global settings that apply to `cpflow` usage.
 # You can opt out of allowing the use of CPLN_ORG and CPLN_APP env vars
 # to avoid any accidents with the wrong org / app.
 allow_org_override_by_env: true
@@ -177,7 +177,7 @@ aliases:
     # Organization for staging and QA apps is typically set as an alias.
     # Production apps will use a different organization, specified in `apps`, for security.
     # Change this value to your organization name
-    # or set the CPLN_ORG env var and it will override this for all `cpl` commands
+    # or set the CPLN_ORG env var and it will override this for all `cpflow` commands
     # (provided that `allow_org_override_by_env` is set to `true`).
     cpln_org: my-org-staging
 
@@ -188,8 +188,8 @@ aliases:
     # CPLN_LOCATION environment variable.
     default_location: aws-us-east-2
 
-    # Allows running the command `cpl setup-app`
-    # instead of `cpl apply-template app redis postgres memcached rails sidekiq`.
+    # Allows running the command `cpflow setup-app`
+    # instead of `cpflow apply-template app redis postgres memcached rails sidekiq`.
     #
     # Note:
     # 1. These names correspond to files in the `./controlplane/templates` directory.
@@ -204,7 +204,7 @@ aliases:
       - rails
       - sidekiq
 
-    # Skips secrets setup when running `cpl setup-app`.
+    # Skips secrets setup when running `cpflow setup-app`.
     skip_secrets_setup: true
 
     # Only needed if using a custom secrets name.
@@ -246,31 +246,31 @@ aliases:
     maintenance_workload: maintenance
 
     # Fixes the remote terminal size to match the local terminal size
-    # when running `cpl run`.
+    # when running `cpflow run`.
     fix_terminal_size: true
 
-    # Sets a default CPU size for `cpl run` jobs (can be overridden per job through `--cpu`).
+    # Sets a default CPU size for `cpflow run` jobs (can be overridden per job through `--cpu`).
     # If not specified, defaults to "1" (1 core).
     runner_job_default_cpu: "2"
 
-    # Sets a default memory size for `cpl run` jobs (can be overridden per job through `--memory`).
+    # Sets a default memory size for `cpflow run` jobs (can be overridden per job through `--memory`).
     # If not specified, defaults to "2Gi" (2 gibibytes).
     runner_job_default_memory: "4Gi"
 
-    # Sets the maximum number of seconds that `cpl run` jobs can execute before being stopped.
+    # Sets the maximum number of seconds that `cpflow run` jobs can execute before being stopped.
     # If not specified, defaults to 21600 (6 hours).
     runner_job_timeout: 1000
 
     # Apps with a deployed image created before this amount of days will be listed for deletion
-    # when running the command `cpl cleanup-stale-apps`.
+    # when running the command `cpflow cleanup-stale-apps`.
     stale_app_image_deployed_days: 5
 
     # Images that exceed this quantity will be listed for deletion
-    # when running the command `cpl cleanup-images`.
+    # when running the command `cpflow cleanup-images`.
     image_retention_max_qty: 20
 
     # Images created before this amount of days will be listed for deletion
-    # when running the command `cpl cleanup-images` (`image_retention_max_qty` takes precedence).
+    # when running the command `cpflow cleanup-images` (`image_retention_max_qty` takes precedence).
     image_retention_days: 5
 
 apps:
@@ -286,12 +286,12 @@ apps:
     match_if_app_name_starts_with: true
 
     # Hooks can be either a script path that exists in the app image or a command.
-    # They're run in the context of `cpl run` with the latest image.
+    # They're run in the context of `cpflow run` with the latest image.
     hooks:
-      # Used by the command `cpl setup-app` to run a hook after creating the app.
+      # Used by the command `cpflow setup-app` to run a hook after creating the app.
       post_creation: bundle exec rake db:prepare
 
-      # Used by the command `cpl delete` to run a hook before deleting the app.
+      # Used by the command `cpflow delete` to run a hook before deleting the app.
       pre_deletion: bundle exec rake db:drop
 
   my-app-production:
@@ -305,11 +305,11 @@ apps:
     # Use a different organization for production.
     cpln_org: my-org-production
 
-    # Allows running the command `cpl promote-app-from-upstream -a my-app-production`
+    # Allows running the command `cpflow promote-app-from-upstream -a my-app-production`
     # to promote the staging app to production.
     upstream: my-app-staging
 
-    # Used by the command `cpl promote-app-from-upstream` to run a release script before deploying.
+    # Used by the command `cpflow promote-app-from-upstream` to run a release script before deploying.
     # This is relative to the `.controlplane/` directory.
     release_script: release_script
 
@@ -337,22 +337,22 @@ Suppose your app is called `tutorial-app`. You can run the following commands.
 ```sh
 # Provision all infrastructure on Control Plane.
 # `tutorial-app` will be created per definition in .controlplane/controlplane.yml.
-cpl apply-template app postgres redis rails daily-task -a tutorial-app
+cpflow apply-template app postgres redis rails daily-task -a tutorial-app
 
 # Build and push the Docker image to the Control Plane repository.
 # Note, it may take many minutes. Be patient.
 # Check for error messages, such as forgetting to run `cpln image docker-login --org <your-org>`.
-cpl build-image -a tutorial-app
+cpflow build-image -a tutorial-app
 
-# Promote the image to the app after running the `cpl build-image` command.
+# Promote the image to the app after running the `cpflow build-image` command.
 # Note, the UX of the images may not show the image for up to 5 minutes. However, it's ready.
-cpl deploy-image -a tutorial-app
+cpflow deploy-image -a tutorial-app
 
 # See how the app is starting up.
-cpl logs -a tutorial-app
+cpflow logs -a tutorial-app
 
 # Open the app in browser (once it has started up).
-cpl open -a tutorial-app
+cpflow open -a tutorial-app
 ```
 
 ### Promoting Code Updates
@@ -361,22 +361,22 @@ After committing code, you will update your deployment of `tutorial-app` with th
 
 ```sh
 # Build and push a new image with sequential image tagging, e.g. 'tutorial-app:1', then 'tutorial-app:2', etc.
-cpl build-image -a tutorial-app
+cpflow build-image -a tutorial-app
 
 # Run database migrations (or other release tasks) with the latest image,
 # while the app is still running on the previous image.
 # This is analogous to the release phase.
-cpl run -a tutorial-app --image latest -- rails db:migrate
+cpflow run -a tutorial-app --image latest -- rails db:migrate
 
 # Pomote the latest image to the app.
-cpl deploy-image -a tutorial-app
+cpflow deploy-image -a tutorial-app
 ```
 
 If you needed to push a new image with a specific commit SHA, you can run the following command:
 
 ```sh
 # Build and push with sequential image tagging and commit SHA, e.g. 'tutorial-app:123_ABCD', etc.
-cpl build-image -a tutorial-app --commit ABCD
+cpflow build-image -a tutorial-app --commit ABCD
 ```
 
 ### Real World
@@ -504,9 +504,9 @@ A complete example can be found at [templates/daily-task.yml](templates/daily-ta
 suitable for development purposes.
 
 You can create the cron workload by adding the template for it to the `.controlplane/templates/` directory and running
-`cpl apply-template my-template -a my-app`, where `my-template` is the name of the template file (e.g., `my-template.yml`).
+`cpflow apply-template my-template -a my-app`, where `my-template` is the name of the template file (e.g., `my-template.yml`).
 
-Then to view the logs of the cron workload, you can run `cpl logs -a my-app -w my-template`.
+Then to view the logs of the cron workload, you can run `cpflow logs -a my-app -w my-template`.
 
 ## CLI Commands Reference
 
@@ -515,19 +515,19 @@ Click [here](/docs/commands.md) to see the commands.
 You can also run the following command:
 
 ```sh
-cpl --help
+cpflow --help
 ```
 
-## Mapping of Heroku Commands to `cpl` and `cpln`
+## Mapping of Heroku Commands to `cpflow` and `cpln`
 
-| Heroku Command                                                                                                 | `cpl` or `cpln`                 |
+| Heroku Command                                                                                                 | `cpflow` or `cpln`                 |
 | -------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| [heroku ps](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-ps-type-type)                     | `cpl ps`                        |
+| [heroku ps](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-ps-type-type)                     | `cpflow ps`                        |
 | [heroku config](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-config)                       | ?                               |
-| [heroku maintenance](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-maintenance)             | `cpl maintenance`               |
-| [heroku logs](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-logs)                           | `cpl logs`                      |
+| [heroku maintenance](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-maintenance)             | `cpflow maintenance`               |
+| [heroku logs](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-logs)                           | `cpflow logs`                      |
 | [heroku pg](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pg-database)                      | ?                               |
-| [heroku pipelines:promote](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pipelines-promote) | `cpl promote-app-from-upstream` |
+| [heroku pipelines:promote](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-pipelines-promote) | `cpflow promote-app-from-upstream` |
 | [heroku psql](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-psql-database)                  | ?                               |
 | [heroku redis](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-redis-database)                | ?                               |
 | [heroku releases](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-releases)                   | ?                               |
@@ -537,7 +537,7 @@ cpl --help
 - See this repository's `examples/` and `templates/` directories.
 - See the `.controlplane/` directory of this live example:
   [react-webpack-rails-tutorial](https://github.com/shakacode/react-webpack-rails-tutorial/tree/master/.controlplane).
-- See [how the `cpl` gem is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
+- See [how the `cpflow` gem is used in the Github actions](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.github/actions/deploy-to-control-plane/action.yml).
 - Here is a brief [video overview](https://www.youtube.com/watch?v=llaQoAV_6Iw).
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ npm update -g @controlplane/cli
 
 5. Run `cpln image docker-login --org <your-org>` to ensure that you have access to the Control Plane Docker registry.
 
-6. Install Heroku to Control Plane `cpflow` CLI as a [Ruby gem](https://rubygems.org/gems/cpflow): `gem install cpflow`. If you want to use `cpflow` from Rake tasks in a Rails project, use `Bundler.with_unbundled_env { `cpflow help` } or else you'll get an error that `cpflow` cannot be found. While you can add `cpflow` to your Gemfile, it's not recommended because it might trigger conflicts with other gems.
+6. Install Control Plane Flow `cpflow` CLI as a [Ruby gem](https://rubygems.org/gems/cpflow): `gem install cpflow`. If you want to use `cpflow` from Rake tasks in a Rails project, use `Bundler.with_unbundled_env { `cpflow help` } or else you'll get an error that `cpflow` cannot be found. While you can add `cpflow` to your Gemfile, it's not recommended because it might trigger conflicts with other gems.
 
 7. You can use [this Dockerfile](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/Dockerfile) as an example for your project. Ensure that you have Docker running.
 
-**Note:** Do not confuse the `cpflow` CLI with the `cpln` CLI. The `cpflow` CLI is the Heroku to Control Plane playbook CLI.
+**Note:** Do not confuse the `cpflow` CLI with the `cpln` CLI. The `cpflow` CLI is the Control Plane Flow playbook CLI.
 The `cpln` CLI is the Control Plane CLI.
 
 ## Steps to Migrate
@@ -543,4 +543,4 @@ cpflow --help
 ## Resources
 * If you need a free demo account for Control Plane (no CC required), you can contact [Justin Gordon, CEO of ShakaCode](mailto:justin@shakacode.com).
 * [Control Plane Site](https://shakacode.controlplane.com)
-* [Join our Slack to Discuss Heroku to Control Plane](https://reactrails.slack.com/join/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE)
+* [Join our Slack to Discuss Control Plane Flow](https://reactrails.slack.com/join/shared_invite/enQtNjY3NTczMjczNzYxLTlmYjdiZmY3MTVlMzU2YWE0OWM0MzNiZDI0MzdkZGFiZTFkYTFkOGVjODBmOWEyYWQ3MzA2NGE1YWJjNmVlMGE)

--- a/bin/cpflow
+++ b/bin/cpflow
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../lib/cpl"
+require_relative "../lib/cpflow"
 
-Cpl::Cli.start
+Cpflow::Cli.start

--- a/cpflow
+++ b/cpflow
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "lib/cpl"
+require_relative "lib/cpflow"
 
-Cpl::Cli.start
+Cpflow::Cli.start

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "lib/cpl/version"
+require_relative "lib/cpflow/version"
 
 Gem::Specification.new do |spec|
-  spec.name    = "cpl"
-  spec.version = Cpl::VERSION
+  spec.name    = "cpflow"
+  spec.version = Cpflow::VERSION
   spec.authors = ["Justin Gordon", "Sergey Tarasov"]
   spec.email   = ["justin@shakacode.com", "sergey@shakacode.com"]
 
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
     file.match(%r{^(coverage|pkg|spec|tmp)/})
   end
 
-  spec.executables = ["cpl"]
+  spec.executables = ["cpflow"]
 
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors = ["Justin Gordon", "Sergey Tarasov"]
   spec.email   = ["justin@shakacode.com", "sergey@shakacode.com"]
 
-  spec.summary     = "Heroku to Control Plane"
+  spec.summary     = "Control Plane Flow"
   spec.description = "CLI for providing Heroku-like platform-as-a-service on Control Plane"
   spec.homepage    = "https://github.com/shakacode/control-plane-flow"
   spec.license     = "MIT"

--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -38,8 +38,4 @@ Gem::Specification.new do |spec|
   spec.executables = ["cpl"]
 
   spec.metadata["rubygems_mfa_required"] = "true"
-
-  spec.post_install_message = "DEPRECATED: The `cpl` gem has been renamed to `cpflow` " \
-                              "and will no longer be supported. " \
-                              "Please switch to `cpflow` as soon as possible."
 end

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -33,10 +33,10 @@ This `-a` option is used in most of the commands and will pick all other app con
 
 ```sh
 # Applies single template.
-cpl apply-template redis -a $APP_NAME
+cpflow apply-template redis -a $APP_NAME
 
 # Applies several templates (practically creating full app).
-cpl apply-template app postgres redis rails -a $APP_NAME
+cpflow apply-template app postgres redis rails -a $APP_NAME
 ```
 
 ### `build-image`
@@ -48,7 +48,7 @@ cpl apply-template app postgres redis rails -a $APP_NAME
 - Accepts extra options that are passed to `docker build`
 
 ```sh
-cpl build-image -a $APP_NAME
+cpflow build-image -a $APP_NAME
 ```
 
 ### `cleanup-images`
@@ -61,7 +61,7 @@ cpl build-image -a $APP_NAME
 - Never deletes the latest image
 
 ```sh
-cpl cleanup-images -a $APP_NAME
+cpflow cleanup-images -a $APP_NAME
 ```
 
 ### `cleanup-stale-apps`
@@ -74,7 +74,7 @@ cpl cleanup-images -a $APP_NAME
 - Will ask for explicit user confirmation
 
 ```sh
-cpl cleanup-stale-apps -a $APP_NAME
+cpflow cleanup-stale-apps -a $APP_NAME
 ```
 
 ### `config`
@@ -83,10 +83,10 @@ cpl cleanup-stale-apps -a $APP_NAME
 
 ```sh
 # Shows the config for each app.
-cpl config
+cpflow config
 
 # Shows the config for a specific app.
-cpl config -a $APP_NAME
+cpflow config -a $APP_NAME
 ```
 
 ### `copy-image-from-upstream`
@@ -98,10 +98,10 @@ cpl config -a $APP_NAME
 
 ```sh
 # Copies the latest image from the source org to the current org.
-cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN
+cpflow copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN
 
 # Copies a specific image from the source org to the current org.
-cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --image appimage:123
+cpflow copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --image appimage:123
 ```
 
 ### `delete`
@@ -115,21 +115,21 @@ cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --ima
 
 ```sh
 # Deletes the whole app (GVC with all workloads, all volumesets and all images).
-cpl delete -a $APP_NAME
+cpflow delete -a $APP_NAME
 
 # Deletes a specific workload.
-cpl delete -a $APP_NAME -w $WORKLOAD_NAME
+cpflow delete -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `deploy-image`
 
 - Deploys the latest image to app workloads
 - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
-- The release script is run in the context of `cpl run` with the latest image
+- The release script is run in the context of `cpflow run` with the latest image
 - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 
 ```sh
-cpl deploy-image -a $APP_NAME
+cpflow deploy-image -a $APP_NAME
 ```
 
 ### `doctor`
@@ -138,13 +138,13 @@ cpl deploy-image -a $APP_NAME
 
 ```sh
 # Runs all validations that don't require additional options by default.
-cpl doctor
+cpflow doctor
 
 # Runs config validation.
-cpl doctor --validations config
+cpflow doctor --validations config
 
 # Runs templates validation (requires app).
-cpl doctor --validations templates -a $APP_NAME
+cpflow doctor --validations templates -a $APP_NAME
 ```
 
 ### `env`
@@ -152,7 +152,7 @@ cpl doctor --validations templates -a $APP_NAME
 - Displays app-specific environment variables
 
 ```sh
-cpl env -a $APP_NAME
+cpflow env -a $APP_NAME
 ```
 
 ### `exists`
@@ -160,7 +160,7 @@ cpl env -a $APP_NAME
 - Shell-checks if an application (GVC) exists, useful in scripts, e.g.:
 
 ```sh
-if [ cpl exists -a $APP_NAME ]; ...
+if [ cpflow exists -a $APP_NAME ]; ...
 ```
 
 ### `generate`
@@ -169,7 +169,7 @@ Creates base Control Plane config and template files
 
 ```sh
 # Creates .controlplane directory with Control Plane config and other templates
-cpl generate
+cpflow generate
 ```
 
 ### `info`
@@ -182,13 +182,13 @@ cpl generate
 
 ```sh
 # Shows diff for all apps in all orgs (based on `.controlplane/controlplane.yml`).
-cpl info
+cpflow info
 
 # Shows diff for all apps in a specific org.
-cpl info -o $ORG_NAME
+cpflow info -o $ORG_NAME
 
 # Shows diff for a specific app.
-cpl info -a $APP_NAME
+cpflow info -a $APP_NAME
 ```
 
 ### `latest-image`
@@ -196,7 +196,7 @@ cpl info -a $APP_NAME
 - Displays the latest image name
 
 ```sh
-cpl latest-image -a $APP_NAME
+cpflow latest-image -a $APP_NAME
 ```
 
 ### `logs`
@@ -206,19 +206,19 @@ cpl latest-image -a $APP_NAME
 
 ```sh
 # Displays logs for the default workload (`one_off_workload`).
-cpl logs -a $APP_NAME
+cpflow logs -a $APP_NAME
 
 # Displays logs for a specific workload.
-cpl logs -a $APP_NAME -w $WORKLOAD_NAME
+cpflow logs -a $APP_NAME -w $WORKLOAD_NAME
 
 # Displays logs for a specific replica of a workload.
-cpl logs -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
+cpflow logs -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
 
 # Uses a different limit on number of entries.
-cpl logs -a $APP_NAME --limit 100
+cpflow logs -a $APP_NAME --limit 100
 
 # Uses a different loopback window.
-cpl logs -a $APP_NAME --since 30min
+cpflow logs -a $APP_NAME --since 30min
 ```
 
 ### `maintenance`
@@ -230,7 +230,7 @@ cpl logs -a $APP_NAME --since 30min
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443
 
 ```sh
-cpl maintenance -a $APP_NAME
+cpflow maintenance -a $APP_NAME
 ```
 
 ### `maintenance:off`
@@ -241,7 +241,7 @@ cpl maintenance -a $APP_NAME
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443
 
 ```sh
-cpl maintenance:off -a $APP_NAME
+cpflow maintenance:off -a $APP_NAME
 ```
 
 ### `maintenance:on`
@@ -252,7 +252,7 @@ cpl maintenance:off -a $APP_NAME
 - Maintenance mode is only supported for domains that use path based routing mode and have a route configured for the prefix '/' on either port 80 or 443
 
 ```sh
-cpl maintenance:on -a $APP_NAME
+cpflow maintenance:on -a $APP_NAME
 ```
 
 ### `maintenance:set-page`
@@ -263,7 +263,7 @@ cpl maintenance:on -a $APP_NAME
 - Optionally specify the maintenance workload through `maintenance_workload` in the `.controlplane/controlplane.yml` file (defaults to 'maintenance')
 
 ```sh
-cpl maintenance:set-page PAGE_URL -a $APP_NAME
+cpflow maintenance:set-page PAGE_URL -a $APP_NAME
 ```
 
 ### `open`
@@ -272,10 +272,10 @@ cpl maintenance:set-page PAGE_URL -a $APP_NAME
 
 ```sh
 # Opens the endpoint of the default workload (`one_off_workload`).
-cpl open -a $APP_NAME
+cpflow open -a $APP_NAME
 
 # Opens the endpoint of a specific workload.
-cpl open -a $APP_NAME -w $WORKLOAD_NAME
+cpflow open -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `open-console`
@@ -284,20 +284,20 @@ cpl open -a $APP_NAME -w $WORKLOAD_NAME
 - Can also go directly to a workload page if `--workload` is provided
 
 ```sh
-cpl open-console -a $APP_NAME
+cpflow open-console -a $APP_NAME
 ```
 
 ### `promote-app-from-upstream`
 
 - Copies the latest image from upstream, runs a release script (optional), and deploys the image
 - It performs the following steps:
-  - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
-  - Runs `cpl deploy-image` to deploy the image
-  - If `.controlplane/controlplane.yml` includes the `release_script`, `cpl deploy-image` will use the `--run-release-phase` option
+  - Runs `cpflow copy-image-from-upstream` to copy the latest image from upstream
+  - Runs `cpflow deploy-image` to deploy the image
+  - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
   - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
 
 ```sh
-cpl promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN
+cpflow promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN
 ```
 
 ### `ps`
@@ -306,10 +306,10 @@ cpl promote-app-from-upstream -a $APP_NAME -t $UPSTREAM_TOKEN
 
 ```sh
 # Shows running replicas in app, for all workloads.
-cpl ps -a $APP_NAME
+cpflow ps -a $APP_NAME
 
 # Shows running replicas in app, for a specific workload.
-cpl ps -a $APP_NAME -w $WORKLOAD_NAME
+cpflow ps -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `ps:restart`
@@ -318,10 +318,10 @@ cpl ps -a $APP_NAME -w $WORKLOAD_NAME
 
 ```sh
 # Forces redeploy of all workloads in app.
-cpl ps:restart -a $APP_NAME
+cpflow ps:restart -a $APP_NAME
 
 # Forces redeploy of a specific workload in app.
-cpl ps:restart -a $APP_NAME -w $WORKLOAD_NAME
+cpflow ps:restart -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `ps:start`
@@ -330,10 +330,10 @@ cpl ps:restart -a $APP_NAME -w $WORKLOAD_NAME
 
 ```sh
 # Starts all workloads in app.
-cpl ps:start -a $APP_NAME
+cpflow ps:start -a $APP_NAME
 
 # Starts a specific workload in app.
-cpl ps:start -a $APP_NAME -w $WORKLOAD_NAME
+cpflow ps:start -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `ps:stop`
@@ -342,13 +342,13 @@ cpl ps:start -a $APP_NAME -w $WORKLOAD_NAME
 
 ```sh
 # Stops all workloads in app.
-cpl ps:stop -a $APP_NAME
+cpflow ps:stop -a $APP_NAME
 
 # Stops a specific workload in app.
-cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME
+cpflow ps:stop -a $APP_NAME -w $WORKLOAD_NAME
 
 # Stops a specific replica of a workload.
-cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
+cpflow ps:stop -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
 ```
 
 ### `ps:wait`
@@ -357,10 +357,10 @@ cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
 
 ```sh
 # Waits for all workloads in app.
-cpl ps:wait -a $APP_NAME
+cpflow ps:wait -a $APP_NAME
 
 # Waits for a specific workload in app.
-cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
+cpflow ps:swait -a $APP_NAME -w $WORKLOAD_NAME
 ```
 
 ### `run`
@@ -385,52 +385,52 @@ cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
 
 ```sh
 # Opens shell (bash by default).
-cpl run -a $APP_NAME
+cpflow run -a $APP_NAME
 
 # Runs interactive command, keeps shell open, and stops job when exiting.
-cpl run -a $APP_NAME --interactive -- rails c
+cpflow run -a $APP_NAME --interactive -- rails c
 
 # Some commands are automatically detected as interactive, so no need to pass `--interactive`.
-cpl run -a $APP_NAME -- bash
-      cpl run -a $APP_NAME -- rails console
-      cpl run -a $APP_NAME -- rails c
-      cpl run -a $APP_NAME -- rails dbconsole
-      cpl run -a $APP_NAME -- rails db
+cpflow run -a $APP_NAME -- bash
+      cpflow run -a $APP_NAME -- rails console
+      cpflow run -a $APP_NAME -- rails c
+      cpflow run -a $APP_NAME -- rails dbconsole
+      cpflow run -a $APP_NAME -- rails db
 
 # Runs non-interactive command, outputs logs, exits with the exit code of the command and stops job.
-cpl run -a $APP_NAME -- rails db:migrate
+cpflow run -a $APP_NAME -- rails db:migrate
 
 # Runs non-iteractive command, detaches, exits with 0, and prints commands to:
 # - see logs from the job
 # - stop the job
-cpl run -a $APP_NAME --detached -- rails db:migrate
+cpflow run -a $APP_NAME --detached -- rails db:migrate
 
 # The command needs to be quoted if setting an env variable or passing args.
-cpl run -a $APP_NAME -- 'SOME_ENV_VAR=some_value rails db:migrate'
+cpflow run -a $APP_NAME -- 'SOME_ENV_VAR=some_value rails db:migrate'
 
 # Uses a different image (which may not be promoted yet).
-cpl run -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
-cpl run -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
+cpflow run -a $APP_NAME --image appimage:123 -- rails db:migrate # Exact image name
+cpflow run -a $APP_NAME --image latest -- rails db:migrate       # Latest sequential image
 
 # Uses a different workload than `one_off_workload` from `.controlplane/controlplane.yml`.
-cpl run -a $APP_NAME -w other-workload -- bash
+cpflow run -a $APP_NAME -w other-workload -- bash
 
 # Overrides remote CPLN_TOKEN env variable with local token.
 # Useful when superuser rights are needed in remote container.
-cpl run -a $APP_NAME --use-local-token -- bash
+cpflow run -a $APP_NAME --use-local-token -- bash
 
 # Replaces the existing Dockerfile entrypoint with `bash`.
-cpl run -a $APP_NAME --entrypoint none -- rails db:migrate
+cpflow run -a $APP_NAME --entrypoint none -- rails db:migrate
 
 # Replaces the existing Dockerfile entrypoint.
-cpl run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:migrate
+cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:migrate
 ```
 
 ### `setup-app`
 
 - Creates an app and all its workloads
 - Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
-- This should only be used for temporary apps like review apps, never for persistent apps like production or staging (to update workloads for those, use 'cpl apply-template' instead)
+- This should only be used for temporary apps like review apps, never for persistent apps like production or staging (to update workloads for those, use 'cpflow apply-template' instead)
 - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
   using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
 - Creates identity for secrets if it does not exist
@@ -441,14 +441,14 @@ cpl run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:mig
 - Use `--skip-post-creation-hook` to skip the hook if specified in `controlplane.yml`
 
 ```sh
-cpl setup-app -a $APP_NAME
+cpflow setup-app -a $APP_NAME
 ```
 
 ### `version`
 
 - Displays the current version of the CLI
-- Can also be done with `cpl --version` or `cpl -v`
+- Can also be done with `cpflow --version` or `cpflow -v`
 
 ```sh
-cpl version
+cpflow version
 ```

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -21,7 +21,7 @@ add-ons to Control Plane later once the app works as expected.
 
 First, create a new Heroku app with all the add-ons, copying the data from the current staging app.
 
-Then, copy project-specific configs to a `.controlplane/` directory at the top of your project. `cpl` will pick those up
+Then, copy project-specific configs to a `.controlplane/` directory at the top of your project. `cpflow` will pick those up
 depending on which project folder tree it runs. Thus, this automates running several projects with different configs
 without explicitly switching configs.
 
@@ -44,7 +44,7 @@ my-app-staging:
 ```
 
 Note how the templates correspond to files in the `.controlplane/templates/` directory. These files will be used by the
-`cpl setup-app` and `cpl apply-template` commands.
+`cpflow setup-app` and `cpflow apply-template` commands.
 
 Ensure that env vars point to the Heroku add-ons in the template for the app (`.controlplane/templates/app.yml`). See
 [this example](https://github.com/shakacode/react-webpack-rails-tutorial/blob/master/.controlplane/templates/gvc.yml).
@@ -87,36 +87,36 @@ Use these commands for the initial setup and deployment:
 
 ```sh
 # Provision infrastructure (one-time-only for new apps) using templates.
-cpl setup-app -a my-app-staging
+cpflow setup-app -a my-app-staging
 
 # Build and push image with auto-tagging, e.g., "my-app-staging:1_456".
-cpl build-image -a my-app-staging --commit 456
+cpflow build-image -a my-app-staging --commit 456
 
 # Prepare database.
-cpl run -a my-app-staging --image latest -- rails db:prepare
+cpflow run -a my-app-staging --image latest -- rails db:prepare
 
 # Deploy latest image.
-cpl deploy-image -a my-app-staging
+cpflow deploy-image -a my-app-staging
 
 # Open app in browser.
-cpl open -a my-app-staging
+cpflow open -a my-app-staging
 ```
 
 Then for promoting code upgrades:
 
 ```sh
 # Build and push new image with sequential tagging, e.g., "my-app-staging:2".
-cpl build-image -a my-app-staging
+cpflow build-image -a my-app-staging
 
 # Or build and push new image with sequential tagging and commit SHA, e.g., "my-app-staging:2_ABC".
-cpl build-image -a my-app-staging --commit ABC
+cpflow build-image -a my-app-staging --commit ABC
 
 # Run database migrations (or other release tasks) with latest image, while app is still running on previous image.
 # This is analogous to the release phase.
-cpl run -a my-app-staging --image latest -- rails db:migrate
+cpflow run -a my-app-staging --image latest -- rails db:migrate
 
 # Deploy latest image.
-cpl deploy-image -a my-app-staging
+cpflow deploy-image -a my-app-staging
 ```
 
 ### Review Special Gems
@@ -208,16 +208,16 @@ echo "export APP_NAME=my-app-review-$PR_NUM" >> $BASH_ENV
 
 # Only create the app if it doesn't exist yet, as we may have multiple triggers for the review app
 # (such as when a PR gets updated).
-if ! cpl exists -a ${APP_NAME}; then
-  cpl setup-app -a ${APP_NAME}
+if ! cpflow exists -a ${APP_NAME}; then
+  cpflow setup-app -a ${APP_NAME}
   echo "export NEW_APP=true" >> $BASH_ENV
 fi
 
 # The `NEW_APP` env var that we exported above can be used to either reset or migrate the database before deploying.
 if [ -n "${NEW_APP}" ]; then
-  cpl run -a ${APP_NAME} --image latest -- rails db:reset
+  cpflow run -a ${APP_NAME} --image latest -- rails db:reset
 else
-  cpl run -a ${APP_NAME} --image latest -- rails db:migrate
+  cpflow run -a ${APP_NAME} --image latest -- rails db:migrate
 fi
 ```
 
@@ -259,4 +259,4 @@ bit simpler to isolate any differences in cost and performance by first moving o
 Ensure that your Control Plane compute is in the AWS region `US-EAST-1`; otherwise, you'll have noticeable extra latency
 with your calls to resources. You might also have egress charges from Control Plane.
 
-Use the `cpl promote-app-from-upstream` command to promote the staging app to production.
+Use the `cpflow promote-app-from-upstream` command to promote the staging app to production.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -44,8 +44,8 @@ heroku redis:cli -a my-app
 Connect to Control Plane Redis CLI:
 
 ```sh
-# open cpl interactive shell
-cpl run bash -a my-app
+# open cpflow interactive shell
+cpflow run bash -a my-app
 
 # install redis CLI if you don't have it in Docker
 apt-get update
@@ -97,7 +97,7 @@ command args:
 1. open 1st terminal window with heroku redis CLI, check keys qty
 2. open 2nd terminal window with controlplane redis CLI, check keys qty
 3. start sync container
-4. open logs with `cpl logs -a my-app -w riot-redis`
+4. open logs with `cpflow logs -a my-app -w riot-redis`
 4. re-check keys sync qty again
 5. stop sync container
 

--- a/docs/secrets-and-env-values.md
+++ b/docs/secrets-and-env-values.md
@@ -23,7 +23,7 @@ You can do this during the initial app setup, like this:
 
 1. Add the template for `app` to `.controlplane/templates`
 2. Ensure that the `app` template is listed in `setup_app_templates` for the app in `.controlplane/controlplane.yml`
-3. Run `cpl setup-app -a $APP_NAME`
+3. Run `cpflow setup-app -a $APP_NAME`
 4. The secrets, secrets policy and identity will be automatically created, along with the proper binding
 5. In the Control Plane console, upper left "Manage Org" menu, click on "Secrets"
 6. Find the created secret (it will be in the `$APP_PREFIX-secrets` format) and add the secret env vars there

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -75,7 +75,7 @@ So `REMOTE_ADDR` should not be used directly, only `request.remote_ip`.
 **Note:** Docker builds much slower on Apple Silicon, so try configuring CI to build the images when using Apple
 hardware.
 
-Make sure to create a profile on CI before running any `cpln` or `cpl` commands.
+Make sure to create a profile on CI before running any `cpln` or `cpflow` commands.
 
 ```sh
 CPLN_TOKEN=...
@@ -111,7 +111,7 @@ allows all workers to finish jobs gracefully before deploying the new image.
 There's no need to unquiet the workers, as that will happen automatically after deploying the new image.
 
 ```sh
-cpl run 'rails runner "Sidekiq::ProcessSet.new.each { |w| w.quiet! unless w[%q(hostname)].start_with?(%q(criticalworker.)) }"' -a my-app
+cpflow run 'rails runner "Sidekiq::ProcessSet.new.each { |w| w.quiet! unless w[%q(hostname)].start_with?(%q(criticalworker.)) }"' -a my-app
 ```
 
 ### Setting Up a Pre Stop Hook

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,4 +3,4 @@
 
 ## App Web Page Shows `upstream request timeout`
 
-If you get a blank screen showing the message `upstream request timeout` on your app after running `cpl open -a my-app-name`, check out the application logs. Your image has been promoted and your app crashing when starting.
+If you get a blank screen showing the message `upstream request timeout` on your app after running `cpflow open -a my-app-name`, check out the application logs. Your image has been promoted and your app crashing when starting.

--- a/examples/circleci.yml
+++ b/examples/circleci.yml
@@ -21,16 +21,16 @@ build-staging:
           cpln profile create default --token ${CPLN_TOKEN} --org ${CPLN_ORG} --gvc ${APP_NAME}
           cpln image docker-login
 
-          gem install cpl
+          gem install cpflow
     - run:
         name: Containerize and push image
-        command: cpl build-image -a ${APP_NAME}
+        command: cpflow build-image -a ${APP_NAME}
     - run:
         name: Database tasks
-        command: cpl run -a ${APP_NAME} --image latest -- rails db:migrate
+        command: cpflow run -a ${APP_NAME} --image latest -- rails db:migrate
     - run:
         name: Deploy image
-        command: cpl deploy-image -a ${APP_NAME}
+        command: cpflow deploy-image -a ${APP_NAME}
 
 # Example config for review app:
 # - triggers manually if needed
@@ -59,29 +59,29 @@ build-review-app:
           cpln profile create default --token ${CPLN_TOKEN} --org ${CPLN_ORG} --gvc ${APP_NAME}
           cpln image docker-login
 
-          gem install cpl
+          gem install cpflow
     - run:
         name: Provision review app if needed
         command: |
-          if ! cpl exists -a ${APP_NAME}; then
-            cpl setup-app -a ${APP_NAME}
+          if ! cpflow exists -a ${APP_NAME}; then
+            cpflow setup-app -a ${APP_NAME}
             echo "export NEW_APP=true" >> $BASH_ENV
           fi
     - run:
         name: Containerize and push image
         command: |
-          cpl build-image -a ${APP_NAME} --commit ${CIRCLE_SHA1::7}
+          cpflow build-image -a ${APP_NAME} --commit ${CIRCLE_SHA1::7}
     - run:
         name: Database tasks
         command: |
           if [ -n "${NEW_APP}" ]; then
-            cpl run -a ${APP_NAME} --image latest -- rails db:reset
+            cpflow run -a ${APP_NAME} --image latest -- rails db:reset
           else
-            cpl run -a ${APP_NAME} --image latest -- rails db:migrate
+            cpflow run -a ${APP_NAME} --image latest -- rails db:migrate
           fi
     - run:
         name: Deploy image
-        command: cpl deploy-image -a ${APP_NAME}
+        command: cpflow deploy-image -a ${APP_NAME}
 
 review-app:
   jobs:

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -1,6 +1,6 @@
 # Keys beginning with "cpln_" correspond to your settings in Control Plane.
 
-# Global settings that apply to `cpl` usage.
+# Global settings that apply to `cpflow` usage.
 # You can opt out of allowing the use of CPLN_ORG and CPLN_APP env vars
 # to avoid any accidents with the wrong org / app.
 allow_org_override_by_env: true
@@ -11,7 +11,7 @@ aliases:
     # Organization for staging and QA apps is typically set as an alias.
     # Production apps will use a different organization, specified in `apps`, for security.
     # Change this value to your organization name
-    # or set the CPLN_ORG env var and it will override this for all `cpl` commands
+    # or set the CPLN_ORG env var and it will override this for all `cpflow` commands
     # (provided that `allow_org_override_by_env` is set to `true`).
     cpln_org: my-org-staging
 
@@ -23,8 +23,8 @@ aliases:
     # TODO: Allow specification of multiple locations.
     default_location: aws-us-east-2
 
-    # Allows running the command `cpl setup-app`
-    # instead of `cpl apply-template app redis postgres memcached rails sidekiq`.
+    # Allows running the command `cpflow setup-app`
+    # instead of `cpflow apply-template app redis postgres memcached rails sidekiq`.
     #
     # Note:
     # 1. These names correspond to files in the `./controlplane/templates` directory.
@@ -39,7 +39,7 @@ aliases:
       - rails
       - sidekiq
 
-    # Uncomment next line to skips secrets setup when running `cpl setup-app`.
+    # Uncomment next line to skips secrets setup when running `cpflow setup-app`.
     # skip_secrets_setup: true
 
     # Only needed if using a custom secrets name.
@@ -81,31 +81,31 @@ aliases:
     maintenance_workload: maintenance
 
     # Fixes the remote terminal size to match the local terminal size
-    # when running `cpl run`.
+    # when running `cpflow run`.
     fix_terminal_size: true
 
-    # Sets a default CPU size for `cpl run` jobs (can be overridden per job through `--cpu`).
+    # Sets a default CPU size for `cpflow run` jobs (can be overridden per job through `--cpu`).
     # If not specified, defaults to "1" (1 core).
     runner_job_default_cpu: "2"
 
-    # Sets a default memory size for `cpl run` jobs (can be overridden per job through `--memory`).
+    # Sets a default memory size for `cpflow run` jobs (can be overridden per job through `--memory`).
     # If not specified, defaults to "2Gi" (2 gibibytes).
     runner_job_default_memory: "4Gi"
 
-    # Sets the maximum number of seconds that `cpl run` jobs can execute before being stopped.
+    # Sets the maximum number of seconds that `cpflow run` jobs can execute before being stopped.
     # If not specified, defaults to 21600 (6 hours).
     runner_job_timeout: 1000
 
     # Apps with a deployed image created before this amount of days will be listed for deletion
-    # when running the command `cpl cleanup-stale-apps`.
+    # when running the command `cpflow cleanup-stale-apps`.
     stale_app_image_deployed_days: 5
 
     # Images that exceed this quantity will be listed for deletion
-    # when running the command `cpl cleanup-images`.
+    # when running the command `cpflow cleanup-images`.
     image_retention_max_qty: 20
 
     # Images created before this amount of days will be listed for deletion
-    # when running the command `cpl cleanup-images` (`image_retention_max_qty` takes precedence).
+    # when running the command `cpflow cleanup-images` (`image_retention_max_qty` takes precedence).
     image_retention_days: 5
 
 apps:
@@ -121,12 +121,12 @@ apps:
     match_if_app_name_starts_with: true
 
     # Hooks can be either a script path that exists in the app image or a command.
-    # They're run in the context of `cpl run` with the latest image.
+    # They're run in the context of `cpflow run` with the latest image.
     hooks:
-      # Used by the command `cpl setup-app` to run a hook after creating the app.
+      # Used by the command `cpflow setup-app` to run a hook after creating the app.
       post_creation: bundle exec rake db:prepare
 
-      # Used by the command `cpl delete` to run a hook before deleting the app.
+      # Used by the command `cpflow delete` to run a hook before deleting the app.
       pre_deletion: bundle exec rake db:drop
 
   my-app-production:
@@ -140,11 +140,11 @@ apps:
     # Use a different organization for production.
     cpln_org: my-org-production
 
-    # Allows running the command `cpl promote-app-from-upstream -a my-app-production`
+    # Allows running the command `cpflow promote-app-from-upstream -a my-app-production`
     # to promote the staging app to production.
     upstream: my-app-staging
 
-    # Used by the command `cpl promote-app-from-upstream` to run a release script before deploying.
+    # Used by the command `cpflow promote-app-from-upstream` to run a release script before deploying.
     # This is relative to the `.controlplane/` directory.
     release_script: release_script
 

--- a/lib/command/apply_template.rb
+++ b/lib/command/apply_template.rb
@@ -34,10 +34,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Applies single template.
-      cpl apply-template redis -a $APP_NAME
+      cpflow apply-template redis -a $APP_NAME
 
       # Applies several templates (practically creating full app).
-      cpl apply-template app postgres redis rails -a $APP_NAME
+      cpflow apply-template app postgres redis rails -a $APP_NAME
       ```
     EX
     VALIDATIONS = %w[config templates].freeze

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -12,9 +12,9 @@ module Command
     VALIDATIONS_WITH_ADDITIONAL_OPTIONS = %w[templates].freeze
     ALL_VALIDATIONS = VALIDATIONS_WITHOUT_ADDITIONAL_OPTIONS + VALIDATIONS_WITH_ADDITIONAL_OPTIONS
 
-    # Used to call the command (`cpl NAME`)
+    # Used to call the command (`cpflow NAME`)
     # NAME = ""
-    # Displayed when running `cpl help` or `cpl help NAME` (defaults to `NAME`)
+    # Displayed when running `cpflow help` or `cpflow help NAME` (defaults to `NAME`)
     USAGE = ""
     # Throws error if `true` and no arguments are passed to the command
     # or if `false` and arguments are passed to the command
@@ -26,13 +26,13 @@ module Command
     # Does not throw error if `true` and extra options
     # that are not specified in `OPTIONS` are passed to the command
     ACCEPTS_EXTRA_OPTIONS = false
-    # Displayed when running `cpl help`
+    # Displayed when running `cpflow help`
     # DESCRIPTION = ""
-    # Displayed when running `cpl help NAME`
+    # Displayed when running `cpflow help NAME`
     # LONG_DESCRIPTION = ""
-    # Displayed along with `LONG_DESCRIPTION` when running `cpl help NAME`
+    # Displayed along with `LONG_DESCRIPTION` when running `cpflow help NAME`
     EXAMPLES = ""
-    # If `true`, hides the command from `cpl help`
+    # If `true`, hides the command from `cpflow help`
     HIDE = false
     # Whether or not to show key information like ORG and APP name in commands
     WITH_INFO_HEADER = true
@@ -527,7 +527,7 @@ module Command
       progress.puts("Running #{title}...\n\n")
 
       begin
-        Cpl::Cli.start(["run", "-a", config.app, "--image", "latest", "--", command])
+        Cpflow::Cli.start(["run", "-a", config.app, "--image", "latest", "--", command])
       rescue SystemExit => e
         progress.puts
 

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -73,7 +73,7 @@ module Command
     end
 
     def delete_app(app)
-      Cpl::Cli.start(["delete", "-a", app, "--yes"])
+      Cpflow::Cli.start(["delete", "-a", app, "--yes"])
     end
   end
 end

--- a/lib/command/config.rb
+++ b/lib/command/config.rb
@@ -13,10 +13,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Shows the config for each app.
-      cpl config
+      cpflow config
 
       # Shows the config for a specific app.
-      cpl config -a $APP_NAME
+      cpflow config -a $APP_NAME
       ```
     EX
 

--- a/lib/command/copy_image_from_upstream.rb
+++ b/lib/command/copy_image_from_upstream.rb
@@ -18,10 +18,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Copies the latest image from the source org to the current org.
-      cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN
+      cpflow copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN
 
       # Copies a specific image from the source org to the current org.
-      cpl copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --image appimage:123
+      cpflow copy-image-from-upstream -a $APP_NAME --upstream-token $UPSTREAM_TOKEN --image appimage:123
       ```
     EX
 

--- a/lib/command/delete.rb
+++ b/lib/command/delete.rb
@@ -21,10 +21,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Deletes the whole app (GVC with all workloads, all volumesets and all images).
-      cpl delete -a $APP_NAME
+      cpflow delete -a $APP_NAME
 
       # Deletes a specific workload.
-      cpl delete -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow delete -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
 

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -11,7 +11,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Deploys the latest image to app workloads
       - Runs a release script before deploying if `release_script` is specified in the `.controlplane/controlplane.yml` file and `--run-release-phase` is provided
-      - The release script is run in the context of `cpl run` with the latest image
+      - The release script is run in the context of `cpflow run` with the latest image
       - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
     DESC
 
@@ -24,7 +24,7 @@ module Command
       if cp.fetch_image_details(image).nil?
         raise "Image '#{image}' does not exist in the Docker repository on Control Plane " \
               "(see https://console.cpln.io/console/org/#{config.org}/repository/#{config.app}). " \
-              "Use `cpl build-image` first."
+              "Use `cpflow build-image` first."
       end
 
       config[:app_workloads].each do |workload|

--- a/lib/command/doctor.rb
+++ b/lib/command/doctor.rb
@@ -14,13 +14,13 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Runs all validations that don't require additional options by default.
-      cpl doctor
+      cpflow doctor
 
       # Runs config validation.
-      cpl doctor --validations config
+      cpflow doctor --validations config
 
       # Runs templates validation (requires app).
-      cpl doctor --validations templates -a $APP_NAME
+      cpflow doctor --validations templates -a $APP_NAME
       ```
     EX
     VALIDATIONS = [].freeze

--- a/lib/command/exists.rb
+++ b/lib/command/exists.rb
@@ -12,7 +12,7 @@ module Command
     DESC
     EXAMPLES = <<~EX
       ```sh
-      if [ cpl exists -a $APP_NAME ]; ...
+      if [ cpflow exists -a $APP_NAME ]; ...
       ```
     EX
 

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -22,7 +22,7 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Creates .controlplane directory with Control Plane config and other templates
-      cpl generate
+      cpflow generate
       ```
     EX
     WITH_INFO_HEADER = false

--- a/lib/command/info.rb
+++ b/lib/command/info.rb
@@ -17,13 +17,13 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Shows diff for all apps in all orgs (based on `.controlplane/controlplane.yml`).
-      cpl info
+      cpflow info
 
       # Shows diff for all apps in a specific org.
-      cpl info -o $ORG_NAME
+      cpflow info -o $ORG_NAME
 
       # Shows diff for a specific app.
-      cpl info -a $APP_NAME
+      cpflow info -a $APP_NAME
       ```
     EX
     WITH_INFO_HEADER = false
@@ -160,9 +160,9 @@ module Command
 
       @missing_apps_workloads.each do |app, workloads|
         if workloads.include?("gvc")
-          puts "  - `cpl setup-app -a #{app}`"
+          puts "  - `cpflow setup-app -a #{app}`"
         else
-          puts "  - `cpl apply-template #{workloads.join(' ')} -a #{app}`"
+          puts "  - `cpflow apply-template #{workloads.join(' ')} -a #{app}`"
         end
       end
     end
@@ -174,7 +174,7 @@ module Command
            "(replace 'whatever' with whatever suffix you want):"
 
       @missing_apps_starting_with.each do |app, _workloads|
-        puts "  - `cpl setup-app -a #{app}-whatever`"
+        puts "  - `cpflow setup-app -a #{app}-whatever`"
       end
     end
 

--- a/lib/command/logs.rb
+++ b/lib/command/logs.rb
@@ -18,19 +18,19 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Displays logs for the default workload (`one_off_workload`).
-      cpl logs -a $APP_NAME
+      cpflow logs -a $APP_NAME
 
       # Displays logs for a specific workload.
-      cpl logs -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow logs -a $APP_NAME -w $WORKLOAD_NAME
 
       # Displays logs for a specific replica of a workload.
-      cpl logs -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
+      cpflow logs -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
 
       # Uses a different limit on number of entries.
-      cpl logs -a $APP_NAME --limit 100
+      cpflow logs -a $APP_NAME --limit 100
 
       # Uses a different loopback window.
-      cpl logs -a $APP_NAME --since 30min
+      cpflow logs -a $APP_NAME --since 30min
       ```
     EX
 

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -39,7 +39,7 @@ module Command
       cp.fetch_workload!(maintenance_workload)
 
       # Start all other workloads
-      Cpl::Cli.start(["ps:start", "-a", config.app, "--wait"])
+      Cpflow::Cli.start(["ps:start", "-a", config.app, "--wait"])
 
       progress.puts
 
@@ -54,7 +54,7 @@ module Command
       progress.puts
 
       # Stop maintenance workload
-      Cpl::Cli.start(["ps:stop", "-a", config.app, "-w", maintenance_workload, "--wait"])
+      Cpflow::Cli.start(["ps:stop", "-a", config.app, "-w", maintenance_workload, "--wait"])
 
       progress.puts("\nMaintenance mode disabled for app '#{config.app}'.")
     end

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -39,7 +39,7 @@ module Command
       cp.fetch_workload!(maintenance_workload)
 
       # Start maintenance workload
-      Cpl::Cli.start(["ps:start", "-a", config.app, "-w", maintenance_workload, "--wait"])
+      Cpflow::Cli.start(["ps:start", "-a", config.app, "-w", maintenance_workload, "--wait"])
 
       progress.puts
 
@@ -54,7 +54,7 @@ module Command
       progress.puts
 
       # Stop all other workloads
-      Cpl::Cli.start(["ps:stop", "-a", config.app, "--wait"])
+      Cpflow::Cli.start(["ps:stop", "-a", config.app, "--wait"])
 
       progress.puts("\nMaintenance mode enabled for app '#{config.app}'.")
     end

--- a/lib/command/no_command.rb
+++ b/lib/command/no_command.rb
@@ -14,9 +14,9 @@ module Command
 
     def call
       if config.options[:version]
-        Cpl::Cli.start(["version"])
+        Cpflow::Cli.start(["version"])
       else
-        Cpl::Cli.start(["help"])
+        Cpflow::Cli.start(["help"])
       end
     end
   end

--- a/lib/command/open.rb
+++ b/lib/command/open.rb
@@ -14,10 +14,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Opens the endpoint of the default workload (`one_off_workload`).
-      cpl open -a $APP_NAME
+      cpflow open -a $APP_NAME
 
       # Opens the endpoint of a specific workload.
-      cpl open -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow open -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
 

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -11,9 +11,9 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Copies the latest image from upstream, runs a release script (optional), and deploys the image
       - It performs the following steps:
-        - Runs `cpl copy-image-from-upstream` to copy the latest image from upstream
-        - Runs `cpl deploy-image` to deploy the image
-        - If `.controlplane/controlplane.yml` includes the `release_script`, `cpl deploy-image` will use the `--run-release-phase` option
+        - Runs `cpflow copy-image-from-upstream` to copy the latest image from upstream
+        - Runs `cpflow deploy-image` to deploy the image
+        - If `.controlplane/controlplane.yml` includes the `release_script`, `cpflow deploy-image` will use the `--run-release-phase` option
         - If the release script exits with a non-zero code, the command will stop executing and also exit with a non-zero code
     DESC
 
@@ -25,14 +25,14 @@ module Command
     private
 
     def copy_image_from_upstream
-      Cpl::Cli.start(["copy-image-from-upstream", "-a", config.app, "-t", config.options[:upstream_token]])
+      Cpflow::Cli.start(["copy-image-from-upstream", "-a", config.app, "-t", config.options[:upstream_token]])
       progress.puts
     end
 
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      Cpl::Cli.start(["deploy-image", "-a", config.app, *args])
+      Cpflow::Cli.start(["deploy-image", "-a", config.app, *args])
     end
   end
 end

--- a/lib/command/ps.rb
+++ b/lib/command/ps.rb
@@ -15,10 +15,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Shows running replicas in app, for all workloads.
-      cpl ps -a $APP_NAME
+      cpflow ps -a $APP_NAME
 
       # Shows running replicas in app, for a specific workload.
-      cpl ps -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow ps -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
     WITH_INFO_HEADER = false

--- a/lib/command/ps_restart.rb
+++ b/lib/command/ps_restart.rb
@@ -14,10 +14,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Forces redeploy of all workloads in app.
-      cpl ps:restart -a $APP_NAME
+      cpflow ps:restart -a $APP_NAME
 
       # Forces redeploy of a specific workload in app.
-      cpl ps:restart -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow ps:restart -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
 

--- a/lib/command/ps_start.rb
+++ b/lib/command/ps_start.rb
@@ -16,10 +16,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Starts all workloads in app.
-      cpl ps:start -a $APP_NAME
+      cpflow ps:start -a $APP_NAME
 
       # Starts a specific workload in app.
-      cpl ps:start -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow ps:start -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
 

--- a/lib/command/ps_stop.rb
+++ b/lib/command/ps_stop.rb
@@ -17,13 +17,13 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Stops all workloads in app.
-      cpl ps:stop -a $APP_NAME
+      cpflow ps:stop -a $APP_NAME
 
       # Stops a specific workload in app.
-      cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow ps:stop -a $APP_NAME -w $WORKLOAD_NAME
 
       # Stops a specific replica of a workload.
-      cpl ps:stop -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
+      cpflow ps:stop -a $APP_NAME -w $WORKLOAD_NAME -r $REPLICA_NAME
       ```
     EX
 

--- a/lib/command/ps_wait.rb
+++ b/lib/command/ps_wait.rb
@@ -15,10 +15,10 @@ module Command
     EXAMPLES = <<~EX
       ```sh
       # Waits for all workloads in app.
-      cpl ps:wait -a $APP_NAME
+      cpflow ps:wait -a $APP_NAME
 
       # Waits for a specific workload in app.
-      cpl ps:swait -a $APP_NAME -w $WORKLOAD_NAME
+      cpflow ps:swait -a $APP_NAME -w $WORKLOAD_NAME
       ```
     EX
 

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -13,7 +13,7 @@ module Command
     LONG_DESCRIPTION = <<~DESC
       - Creates an app and all its workloads
       - Specify the templates for the app and workloads through `setup_app_templates` in the `.controlplane/controlplane.yml` file
-      - This should only be used for temporary apps like review apps, never for persistent apps like production or staging (to update workloads for those, use 'cpl apply-template' instead)
+      - This should only be used for temporary apps like review apps, never for persistent apps like production or staging (to update workloads for those, use 'cpflow apply-template' instead)
       - Configures app to have org-level secrets with default name "{APP_PREFIX}-secrets"
         using org-level policy with default name "{APP_PREFIX}-secrets-policy" (names can be customized, see docs)
       - Creates identity for secrets if it does not exist
@@ -31,8 +31,8 @@ module Command
       app = cp.fetch_gvc
       if app
         raise "App '#{config.app}' already exists. If you want to update this app, " \
-              "either run 'cpl delete -a #{config.app}' and then re-run this command, " \
-              "or run 'cpl apply-template #{templates.join(' ')} -a #{config.app}'."
+              "either run 'cpflow delete -a #{config.app}' and then re-run this command, " \
+              "or run 'cpflow apply-template #{templates.join(' ')} -a #{config.app}'."
       end
 
       skip_secrets_setup = config.options[:skip_secret_access_binding] ||
@@ -42,7 +42,7 @@ module Command
 
       args = []
       args.push("--add-app-identity") unless skip_secrets_setup
-      Cpl::Cli.start(["apply-template", *templates, "-a", config.app, *args])
+      Cpflow::Cli.start(["apply-template", *templates, "-a", config.app, *args])
 
       bind_identity_to_policy unless skip_secrets_setup
       run_post_creation_hook unless config.options[:skip_post_creation_hook]

--- a/lib/command/test.rb
+++ b/lib/command/test.rb
@@ -16,8 +16,8 @@ module Command
     def call
       # Modify this method to trigger the code you want to test.
       # You can use `debugger` to debug.
-      # You can use `Cpl::Cli.start` to simulate a command
-      # (e.g., `Cpl::Cli.start(["deploy-image", "-a", "my-app-name"])`).
+      # You can use `Cpflow::Cli.start` to simulate a command
+      # (e.g., `Cpflow::Cli.start(["deploy-image", "-a", "my-app-name"])`).
     end
   end
 end

--- a/lib/command/version.rb
+++ b/lib/command/version.rb
@@ -6,13 +6,13 @@ module Command
     DESCRIPTION = "Displays the current version of the CLI"
     LONG_DESCRIPTION = <<~DESC
       - Displays the current version of the CLI
-      - Can also be done with `cpl --version` or `cpl -v`
+      - Can also be done with `cpflow --version` or `cpflow -v`
     DESC
     WITH_INFO_HEADER = false
     VALIDATIONS = [].freeze
 
     def call
-      puts Cpl::VERSION
+      puts Cpflow::VERSION
     end
   end
 end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -155,7 +155,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     gvc_data = fetch_gvc(a_gvc)
     return gvc_data if gvc_data
 
-    raise "Can't find app '#{gvc}', please create it with 'cpl setup-app -a #{config.app}'."
+    raise "Can't find app '#{gvc}', please create it with 'cpflow setup-app -a #{config.app}'."
   end
 
   def gvc_delete(a_gvc = gvc)
@@ -180,7 +180,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     workload_data = fetch_workload(workload)
     return workload_data if workload_data
 
-    raise "Can't find workload '#{workload}', please create it with 'cpl apply-template #{workload} -a #{config.app}'."
+    raise "Can't find workload '#{workload}', " \
+          "please create it with 'cpflow apply-template #{workload} -a #{config.app}'."
   end
 
   def query_workloads(workload, a_gvc = gvc, a_org = org, partial_workload_match: false, partial_gvc_match: nil)

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -50,18 +50,18 @@ class Thor
   end
 end
 
-module Cpl
+module Cpflow
   class Error < StandardError; end
 
   class Cli < Thor # rubocop:disable Metrics/ClassLength
-    package_name "cpl"
+    package_name "cpflow"
     default_task :no_command
 
     def self.start(*args)
       ENV["CPLN_SKIP_UPDATE_CHECK"] = "true"
 
       check_cpln_version
-      check_cpl_version
+      check_cpflow_version
       fix_help_option
 
       super(*args)
@@ -77,7 +77,7 @@ module Cpl
         data = JSON.parse(result[:output])
 
         version = data["npm"]
-        min_version = Cpl::MIN_CPLN_VERSION
+        min_version = Cpflow::MIN_CPLN_VERSION
         if Gem::Version.new(version) < Gem::Version.new(min_version)
           ::Shell.abort("Current 'cpln' version: #{version}. Minimum supported version: #{min_version}. " \
                         "Please update it with 'npm update -g @controlplane/cli'.")
@@ -87,27 +87,27 @@ module Cpl
       end
     end
 
-    def self.check_cpl_version # rubocop:disable Metrics/MethodLength
-      return if @checked_cpl_version
+    def self.check_cpflow_version # rubocop:disable Metrics/MethodLength
+      return if @checked_cpflow_version
 
-      @checked_cpl_version = true
+      @checked_cpflow_version = true
 
-      result = ::Shell.cmd("gem", "search", "^cpl$", "--remote", capture_stderr: true)
+      result = ::Shell.cmd("gem", "search", "^cpflow$", "--remote", capture_stderr: true)
       return unless result[:success]
 
-      matches = result[:output].match(/cpl \((.+)\)/)
+      matches = result[:output].match(/cpflow \((.+)\)/)
       return unless matches
 
-      version = Cpl::VERSION
+      version = Cpflow::VERSION
       latest_version = matches[1]
       return unless Gem::Version.new(version) < Gem::Version.new(latest_version)
 
-      ::Shell.warn("You are not using the latest 'cpl' version. Please update it with 'gem update cpl'.")
+      ::Shell.warn("You are not using the latest 'cpflow' version. Please update it with 'gem update cpflow'.")
       $stderr.puts
     end
 
-    # This is so that we're able to run `cpl COMMAND --help` to print the help
-    # (it basically changes it to `cpl --help COMMAND`, which Thor recognizes)
+    # This is so that we're able to run `cpflow COMMAND --help` to print the help
+    # (it basically changes it to `cpflow --help COMMAND`, which Thor recognizes)
     # Based on https://stackoverflow.com/questions/49042591/how-to-add-help-h-flag-to-thor-command
     def self.fix_help_option
       help_mappings = Thor::HELP_MAPPINGS + ["help"]
@@ -149,7 +149,7 @@ module Cpl
     end
 
     def self.process_option_params(params)
-      # Ensures that if no value is provided for a non-boolean option (e.g., `cpl command --option`),
+      # Ensures that if no value is provided for a non-boolean option (e.g., `cpflow command --option`),
       # it defaults to an empty string instead of the option name (which is the default Thor behavior)
       params[:lazy_default] ||= "" if params[:type] != :boolean
 
@@ -220,11 +220,11 @@ module Cpl
         end
 
         begin
-          Cpl::Cli.validate_options!(options)
+          Cpflow::Cli.validate_options!(options)
 
           config = Config.new(args, options, required_options)
 
-          Cpl::Cli.show_info_header(config) if with_info_header
+          Cpflow::Cli.show_info_header(config) if with_info_header
 
           if validations.any? && ENV.fetch("DISABLE_VALIDATIONS", nil) != "true"
             doctor = DoctorService.new(config)

--- a/lib/cpflow/version.rb
+++ b/lib/cpflow/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Cpl
+module Cpflow
   VERSION = "2.2.4"
   MIN_CPLN_VERSION = "2.0.1"
 end

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -60,22 +60,11 @@ module Cpl
     def self.start(*args)
       ENV["CPLN_SKIP_UPDATE_CHECK"] = "true"
 
-      warn_deprecated_gem
       check_cpln_version
       check_cpl_version
       fix_help_option
 
       super(*args)
-    end
-
-    def self.warn_deprecated_gem
-      return if @warned_deprecated_gem
-
-      @warned_deprecated_gem = true
-
-      ::Shell.warn_deprecated("This gem has been renamed to `cpflow` " \
-                              "and will no longer be supported. " \
-                              "Please switch to `cpflow` as soon as possible.")
     end
 
     def self.check_cpln_version # rubocop:disable Metrics/MethodLength

--- a/lib/generator_templates/controlplane.yml
+++ b/lib/generator_templates/controlplane.yml
@@ -53,7 +53,7 @@ apps:
 
     # Use a different organization for production.
     cpln_org: my-org-production
-    # Allows running the command `cpl promote-app-from-upstream -a my-app-production`
+    # Allows running the command `cpflow promote-app-from-upstream -a my-app-production`
     # to promote the staging app to production.
     upstream: my-app-staging
   my-app-other:

--- a/script/update_command_docs
+++ b/script/update_command_docs
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../lib/cpl"
+require_relative "../lib/cpflow"
 
 commands_str_arr = []
 
@@ -29,7 +29,7 @@ commands.keys.sort.each do |command_key|
     end
     options_str = options_str_arr.join(" ")
 
-    command_str += "```sh\ncpl #{usage}"
+    command_str += "```sh\ncpflow #{usage}"
     command_str += " #{options_str}" unless options_str.empty?
     command_str += "\n```"
   else

--- a/spec/command/apply_template_spec.rb
+++ b/spec/command/apply_template_spec.rb
@@ -7,7 +7,7 @@ describe Command::ApplyTemplate do
     let!(:app) { dummy_test_app }
 
     it "raises error" do
-      result = run_cpl_command("apply-template", "app", "rails", "nonexistent", "-a", app)
+      result = run_cpflow_command("apply-template", "app", "rails", "nonexistent", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Missing templates")
@@ -19,11 +19,11 @@ describe Command::ApplyTemplate do
     let!(:app) { dummy_test_app }
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "applies valid templates" do
-      result = run_cpl_command("apply-template", "app", "rails", "-a", app)
+      result = run_cpflow_command("apply-template", "app", "rails", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Created items")
@@ -33,7 +33,7 @@ describe Command::ApplyTemplate do
     end
 
     it "fails to apply invalid templates" do
-      result = run_cpl_command("apply-template", "invalid", "-a", app)
+      result = run_cpflow_command("apply-template", "invalid", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Failed to apply templates")
@@ -41,7 +41,7 @@ describe Command::ApplyTemplate do
     end
 
     it "applies valid templates and fails to apply invalid templates" do
-      result = run_cpl_command("apply-template", "app", "invalid", "rails", "-a", app)
+      result = run_cpflow_command("apply-template", "app", "invalid", "rails", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Created items")
@@ -53,8 +53,8 @@ describe Command::ApplyTemplate do
     end
 
     it "replaces all variables correctly" do
-      apply_result = run_cpl_command("apply-template", "app-with-all-variables", "-a", app)
-      env_result = run_cpl_command("env", "-a", app)
+      apply_result = run_cpflow_command("apply-template", "app-with-all-variables", "-a", app)
+      env_result = run_cpflow_command("env", "-a", app)
 
       org = dummy_test_org
       location = "aws-us-east-2"
@@ -76,8 +76,8 @@ describe Command::ApplyTemplate do
     end
 
     it "replaces deprecated variables correctly" do
-      apply_result = run_cpl_command("apply-template", "app-with-deprecated-variables", "-a", app)
-      env_result = run_cpl_command("env", "-a", app)
+      apply_result = run_cpflow_command("apply-template", "app-with-deprecated-variables", "-a", app)
+      env_result = run_cpflow_command("env", "-a", app)
 
       org = dummy_test_org
       location = "aws-us-east-2"
@@ -97,7 +97,7 @@ describe Command::ApplyTemplate do
     it "asks for confirmation and does nothing" do
       allow(Shell).to receive(:confirm).with(include("App '#{app}' already exists")).and_return(false)
 
-      result = run_cpl_command("apply-template", "app", "-a", app)
+      result = run_cpflow_command("apply-template", "app", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -108,7 +108,7 @@ describe Command::ApplyTemplate do
     it "asks for confirmation and re-creates app" do
       allow(Shell).to receive(:confirm).with(include("App '#{app}' already exists")).and_return(true)
 
-      result = run_cpl_command("apply-template", "app", "-a", app)
+      result = run_cpflow_command("apply-template", "app", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -119,7 +119,7 @@ describe Command::ApplyTemplate do
     it "skips confirmation and re-creates app" do
       allow(Shell).to receive(:confirm).and_return(false)
 
-      result = run_cpl_command("apply-template", "app", "-a", app, "--yes")
+      result = run_cpflow_command("apply-template", "app", "-a", app, "--yes")
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
@@ -134,7 +134,7 @@ describe Command::ApplyTemplate do
     it "asks for confirmation and does nothing" do
       allow(Shell).to receive(:confirm).with(include("Workload 'rails' already exists")).and_return(false)
 
-      result = run_cpl_command("apply-template", "rails", "-a", app)
+      result = run_cpflow_command("apply-template", "rails", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -145,7 +145,7 @@ describe Command::ApplyTemplate do
     it "asks for confirmation and re-creates workload" do
       allow(Shell).to receive(:confirm).with(include("Workload 'rails' already exists")).and_return(true)
 
-      result = run_cpl_command("apply-template", "rails", "-a", app)
+      result = run_cpflow_command("apply-template", "rails", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -156,7 +156,7 @@ describe Command::ApplyTemplate do
     it "skips confirmation and re-creates workload" do
       allow(Shell).to receive(:confirm).and_return(false)
 
-      result = run_cpl_command("apply-template", "rails", "-a", app, "--yes")
+      result = run_cpflow_command("apply-template", "rails", "-a", app, "--yes")
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)

--- a/spec/command/build_image_spec.rb
+++ b/spec/command/build_image_spec.rb
@@ -11,7 +11,7 @@ describe Command::BuildImage do
     end
 
     it "raises error" do
-      result = run_cpl_command("build-image", "-a", app)
+      result = run_cpflow_command("build-image", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't run Docker")
@@ -22,7 +22,7 @@ describe Command::BuildImage do
     let!(:app) { dummy_test_app("nonexistent-dockerfile") }
 
     it "raises error" do
-      result = run_cpl_command("build-image", "-a", app)
+      result = run_cpflow_command("build-image", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find Dockerfile")
@@ -33,7 +33,7 @@ describe Command::BuildImage do
     let!(:app) { dummy_test_app("invalid-dockerfile") }
 
     it "fails to build and push image" do
-      result = run_cpl_command("build-image", "-a", app)
+      result = run_cpflow_command("build-image", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).not_to include("Pushed image")
@@ -44,19 +44,19 @@ describe Command::BuildImage do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "builds and pushes images", :slow do
-      result1 = run_cpl_command("build-image", "-a", app)
+      result1 = run_cpflow_command("build-image", "-a", app)
       # Subsequent build increases number
-      result2 = run_cpl_command("build-image", "-a", app)
+      result2 = run_cpflow_command("build-image", "-a", app)
       # Adds commit hash
-      result3 = run_cpl_command("build-image", "-a", app, "--commit", "abc123")
+      result3 = run_cpflow_command("build-image", "-a", app, "--commit", "abc123")
 
       expect(result1[:status]).to eq(0)
       expect(result2[:status]).to eq(0)
@@ -70,7 +70,7 @@ describe Command::BuildImage do
       allow(Process).to receive(:spawn).with(match(/docker build.+?TEST=123/)).and_call_original
       allow(Process).to receive(:spawn).with(include("docker push")).and_call_original
 
-      result = run_cpl_command("build-image", "-a", app, "--build-arg", "TEST=123")
+      result = run_cpflow_command("build-image", "-a", app, "--build-arg", "TEST=123")
 
       expect(Process).to have_received(:spawn).twice
       expect(result[:status]).to eq(0)

--- a/spec/command/cleanup_images_spec.rb
+++ b/spec/command/cleanup_images_spec.rb
@@ -7,7 +7,7 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find either option 'image_retention_max_qty' or 'image_retention_days'")
@@ -18,7 +18,7 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app }
 
     it "displays message" do
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("No images to delete")
@@ -29,14 +29,14 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("build-image", "-a", app) # app:1
+      run_cpflow_command!("build-image", "-a", app) # app:1
     end
 
     it "deletes leftover images", :slow do
       allow(Shell).to receive(:confirm).with(include("1 images")).and_return(true)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -49,20 +49,20 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
-      run_cpl_command!("build-image", "-a", app) # app:1
-      run_cpl_command!("build-image", "-a", app) # app:2
+      run_cpflow_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("build-image", "-a", app) # app:1
+      run_cpflow_command!("build-image", "-a", app) # app:2
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "asks for confirmation and does nothing", :slow do
       allow(Shell).to receive(:confirm).with(include("1 images")).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -74,7 +74,7 @@ describe Command::CleanupImages do
       allow(Shell).to receive(:confirm).with(include("1 images")).and_return(true)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -86,7 +86,7 @@ describe Command::CleanupImages do
       allow(Shell).to receive(:confirm).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app, "--yes")
+      result = run_cpflow_command("cleanup-images", "-a", app, "--yes")
       travel_back
 
       expect(Shell).not_to have_received(:confirm)
@@ -99,26 +99,26 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app("image-retention-max-qty") }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "lists correct images", :slow do
       allow(Shell).to receive(:confirm).with(include("2 images")).and_return(false)
 
       # Excess images, will be listed
-      run_cpl_command!("build-image", "-a", app) # app:1
-      run_cpl_command!("build-image", "-a", app) # app:2
+      run_cpflow_command!("build-image", "-a", app) # app:1
+      run_cpflow_command!("build-image", "-a", app) # app:2
       # Images that don't exceed max quantity of 3, won't be listed
-      run_cpl_command!("build-image", "-a", app) # app:3
-      run_cpl_command!("build-image", "-a", app) # app:4
-      run_cpl_command!("build-image", "-a", app) # app:5
+      run_cpflow_command!("build-image", "-a", app) # app:3
+      run_cpflow_command!("build-image", "-a", app) # app:4
+      run_cpflow_command!("build-image", "-a", app) # app:5
       # Latest image, excluded from max quantity calculation, won't be listed
-      run_cpl_command!("build-image", "-a", app) # app:6
-      result = run_cpl_command("cleanup-images", "-a", app)
+      run_cpflow_command!("build-image", "-a", app) # app:6
+      result = run_cpflow_command("cleanup-images", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -131,23 +131,23 @@ describe Command::CleanupImages do
     let!(:app) { dummy_test_app("image-retention-days") }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "lists correct images", :slow do
       allow(Shell).to receive(:confirm).with(include("2 images")).and_return(false)
 
       # Old images, will be listed
-      run_cpl_command!("build-image", "-a", app) # app:1
-      run_cpl_command!("build-image", "-a", app) # app:2
+      run_cpflow_command!("build-image", "-a", app) # app:1
+      run_cpflow_command!("build-image", "-a", app) # app:2
       # Latest image, excluded from days calculation, won't be listed
-      run_cpl_command!("build-image", "-a", app) # app:3
+      run_cpflow_command!("build-image", "-a", app) # app:3
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app)
+      result = run_cpflow_command("cleanup-images", "-a", app)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -166,7 +166,7 @@ describe Command::CleanupImages do
       allow(Shell).to receive(:confirm).with(include("2 images")).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app1)
+      result = run_cpflow_command("cleanup-images", "-a", app1)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -179,7 +179,7 @@ describe Command::CleanupImages do
       allow(Shell).to receive(:confirm).with(include("4 images")).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-images", "-a", app_prefix)
+      result = run_cpflow_command("cleanup-images", "-a", app_prefix)
       travel_back
 
       expect(Shell).to have_received(:confirm).once

--- a/spec/command/cleanup_stale_apps_spec.rb
+++ b/spec/command/cleanup_stale_apps_spec.rb
@@ -9,7 +9,7 @@ describe Command::CleanupStaleApps do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("cleanup-stale-apps", "-a", app)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'stale_app_image_deployed_days'")
@@ -20,7 +20,7 @@ describe Command::CleanupStaleApps do
     let!(:app) { dummy_test_app }
 
     it "displays message" do
-      result = run_cpl_command("cleanup-stale-apps", "-a", app)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("No stale apps found")
@@ -32,22 +32,22 @@ describe Command::CleanupStaleApps do
     let!(:app2) { dummy_test_app("stale-app") }
 
     before do
-      run_cpl_command!("apply-template", "app", "postgres-with-volume", "-a", app1)
-      run_cpl_command!("apply-template", "app", "postgres-with-volume", "-a", app2)
-      run_cpl_command!("build-image", "-a", app1)
-      run_cpl_command!("build-image", "-a", app2)
+      run_cpflow_command!("apply-template", "app", "postgres-with-volume", "-a", app1)
+      run_cpflow_command!("apply-template", "app", "postgres-with-volume", "-a", app2)
+      run_cpflow_command!("build-image", "-a", app1)
+      run_cpflow_command!("build-image", "-a", app2)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app1, "--yes")
-      run_cpl_command!("delete", "-a", app2, "--yes")
+      run_cpflow_command!("delete", "-a", app1, "--yes")
+      run_cpflow_command!("delete", "-a", app2, "--yes")
     end
 
     it "asks for confirmation and does nothing", :slow do
       allow(Shell).to receive(:confirm).with(include("2 apps")).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-stale-apps", "-a", app_prefix)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -59,7 +59,7 @@ describe Command::CleanupStaleApps do
       allow(Shell).to receive(:confirm).with(include("2 apps")).and_return(true)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-stale-apps", "-a", app_prefix)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)
       travel_back
 
       expect(Shell).to have_received(:confirm).once
@@ -76,7 +76,7 @@ describe Command::CleanupStaleApps do
       allow(Shell).to receive(:confirm).and_return(false)
 
       travel_to_days_later(30)
-      result = run_cpl_command("cleanup-stale-apps", "-a", app_prefix, "--yes")
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix, "--yes")
       travel_back
 
       expect(Shell).not_to have_received(:confirm)
@@ -97,17 +97,17 @@ describe Command::CleanupStaleApps do
     let!(:app4) { dummy_test_app("stale-app") }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app1)
-      run_cpl_command!("apply-template", "app", "-a", app2)
-      run_cpl_command!("apply-template", "app", "-a", app3)
-      run_cpl_command!("apply-template", "app", "-a", app4)
+      run_cpflow_command!("apply-template", "app", "-a", app1)
+      run_cpflow_command!("apply-template", "app", "-a", app2)
+      run_cpflow_command!("apply-template", "app", "-a", app3)
+      run_cpflow_command!("apply-template", "app", "-a", app4)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app1, "--yes")
-      run_cpl_command!("delete", "-a", app2, "--yes")
-      run_cpl_command!("delete", "-a", app3, "--yes")
-      run_cpl_command!("delete", "-a", app4, "--yes")
+      run_cpflow_command!("delete", "-a", app1, "--yes")
+      run_cpflow_command!("delete", "-a", app2, "--yes")
+      run_cpflow_command!("delete", "-a", app3, "--yes")
+      run_cpflow_command!("delete", "-a", app4, "--yes")
     end
 
     it "lists correct stale apps", :slow do
@@ -124,12 +124,12 @@ describe Command::CleanupStaleApps do
       end
 
       # Apps with old image, will be listed
-      run_cpl_command!("build-image", "-a", app1)
-      run_cpl_command!("build-image", "-a", app2)
+      run_cpflow_command!("build-image", "-a", app1)
+      run_cpflow_command!("build-image", "-a", app2)
       travel_to_days_later(30)
       # App with new image, wont't be listed
-      run_cpl_command!("build-image", "-a", app3)
-      result = run_cpl_command("cleanup-stale-apps", "-a", app_prefix)
+      run_cpflow_command!("build-image", "-a", app3)
+      result = run_cpflow_command("cleanup-stale-apps", "-a", app_prefix)
       travel_back
 
       expect(Shell).to have_received(:confirm).once

--- a/spec/command/config_spec.rb
+++ b/spec/command/config_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe Command::Config do
   context "when no app is provided" do
     it "displays config for each app" do
-      result = run_cpl_command("config")
+      result = run_cpflow_command("config")
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("Config for app 'dummy-test-#{dummy_test_app_global_identifier}'")
@@ -19,7 +19,7 @@ describe Command::Config do
     let!(:app) { dummy_test_app }
 
     it "displays config for specific app" do
-      result = run_cpl_command("config", "-a", app)
+      result = run_cpflow_command("config", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("Current config (app '#{app}')")

--- a/spec/command/copy_image_from_upstream_spec.rb
+++ b/spec/command/copy_image_from_upstream_spec.rb
@@ -12,7 +12,7 @@ describe Command::CopyImageFromUpstream do
     end
 
     it "raises error" do
-      result = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
+      result = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't run Docker")
@@ -23,7 +23,7 @@ describe Command::CopyImageFromUpstream do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
+      result = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'upstream'")
@@ -34,7 +34,7 @@ describe Command::CopyImageFromUpstream do
     let!(:app) { dummy_test_app("undefined-upstream") }
 
     it "raises error" do
-      result = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
+      result = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'cpln_org' for app 'undefined'")
@@ -50,7 +50,7 @@ describe Command::CopyImageFromUpstream do
     end
 
     it "raises error" do
-      result = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
+      result = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'cpln_org' for app '#{upstream_app}'")
@@ -66,18 +66,18 @@ describe Command::CopyImageFromUpstream do
       # Ideally, we should have a different org, but for testing purposes, this works
       ENV["CPLN_ORG_UPSTREAM"] = dummy_test_org
 
-      run_cpl_command!("apply-template", "app", "-a", upstream_app)
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", upstream_app, "--yes")
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "fails to fetch upstream image URL", :slow do
-      run_cpl_command!("build-image", "-a", upstream_app)
-      result = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
+      run_cpflow_command!("build-image", "-a", upstream_app)
+      result = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", "token")
 
       expect(ENV.fetch("CPLN_PROFILE", nil)).to eq("default")
       expect(result[:status]).not_to eq(0)
@@ -97,26 +97,26 @@ describe Command::CopyImageFromUpstream do
       # Ideally, we should have a different org, but for testing purposes, this works
       ENV["CPLN_ORG_UPSTREAM"] = dummy_test_org
 
-      run_cpl_command!("apply-template", "app", "-a", upstream_app)
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", upstream_app, "--yes")
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "copies images from upstream", :slow do
       # Simulates looping through generated profile names to avoid conflicts
       allow_any_instance_of(Controlplane).to receive(:profile_exists?).and_return(true, false) # rubocop:disable RSpec/AnyInstance
 
-      run_cpl_command!("build-image", "-a", upstream_app, "--commit", "abc123")
-      run_cpl_command!("build-image", "-a", upstream_app)
+      run_cpflow_command!("build-image", "-a", upstream_app, "--commit", "abc123")
+      run_cpflow_command!("build-image", "-a", upstream_app)
       # Copies latest image
-      result1 = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", token)
+      result1 = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", token)
       # Copies specific image with commit hash
-      result2 = run_cpl_command("copy-image-from-upstream", "-a", app, "--upstream-token", token,
-                                "--image", "#{upstream_app}:1_abc123")
+      result2 = run_cpflow_command("copy-image-from-upstream", "-a", app, "--upstream-token", token,
+                                   "--image", "#{upstream_app}:1_abc123")
 
       expect(ENV.fetch("CPLN_PROFILE", nil)).to eq("default")
       expect(result1[:status]).to eq(0)

--- a/spec/command/delete_spec.rb
+++ b/spec/command/delete_spec.rb
@@ -7,7 +7,7 @@ describe Command::Delete do
     let!(:app) { dummy_test_app }
 
     it "displays message" do
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("App '#{app}' does not exist")
@@ -18,17 +18,17 @@ describe Command::Delete do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "asks for confirmation and does nothing" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(false)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -40,7 +40,7 @@ describe Command::Delete do
     it "asks for confirmation and deletes app" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -52,7 +52,7 @@ describe Command::Delete do
     it "skips confirmation and deletes app" do
       allow(Shell).to receive(:confirm).and_return(false)
 
-      result = run_cpl_command("delete", "-a", app, "--yes")
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
@@ -66,18 +66,18 @@ describe Command::Delete do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "rails", "postgres-with-volume", "detached-volume", "-a", app)
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("apply-template", "app", "rails", "postgres-with-volume", "detached-volume", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "deletes app with volumesets and images", :slow do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -92,15 +92,15 @@ describe Command::Delete do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "displays message" do
-      result = run_cpl_command("delete", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("delete", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Workload 'rails' does not exist in app '#{app}'")
@@ -111,17 +111,17 @@ describe Command::Delete do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "rails", "-a", app)
+      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "asks for confirmation and does nothing" do
       allow(Shell).to receive(:confirm).with(include("rails")).and_return(false)
 
-      result = run_cpl_command("delete", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("delete", "-a", app, "--workload", "rails")
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -131,7 +131,7 @@ describe Command::Delete do
     it "asks for confirmation and deletes workload" do
       allow(Shell).to receive(:confirm).with(include("rails")).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("delete", "-a", app, "--workload", "rails")
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -141,7 +141,7 @@ describe Command::Delete do
     it "skips confirmation and deletes workload" do
       allow(Shell).to receive(:confirm).and_return(false)
 
-      result = run_cpl_command("delete", "-a", app, "--workload", "rails", "--yes")
+      result = run_cpflow_command("delete", "-a", app, "--workload", "rails", "--yes")
 
       expect(Shell).not_to have_received(:confirm)
       expect(result[:status]).to eq(0)
@@ -153,13 +153,13 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("nonexistent-identity") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
+      run_cpflow_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -172,13 +172,13 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("nonexistent-policy") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
+      run_cpflow_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -191,13 +191,13 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("secrets") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
+      run_cpflow_command!("setup-app", "-a", app, "--skip-secrets-setup")
     end
 
     it "does not unbind identity from policy" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -210,13 +210,13 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("secrets") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app)
+      run_cpflow_command!("setup-app", "-a", app)
     end
 
     it "unbinds identity from policy" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app)
+      result = run_cpflow_command("delete", "-a", app)
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
@@ -229,18 +229,18 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("invalid-pre-deletion-hook") }
 
     before do
-      run_cpl_command!("build-image", "-a", app)
-      run_cpl_command!("setup-app", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
+      run_cpflow_command!("setup-app", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes", "--skip-pre-deletion-hook")
+      run_cpflow_command!("delete", "-a", app, "--yes", "--skip-pre-deletion-hook")
     end
 
     it "fails to run hook", :slow do
       result = nil
 
-      spawn_cpl_command("delete", "-a", app, "--yes") do |it|
+      spawn_cpflow_command("delete", "-a", app, "--yes") do |it|
         result = it.read_full_output
       end
 
@@ -253,14 +253,14 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("valid-pre-deletion-hook") }
 
     before do
-      run_cpl_command!("build-image", "-a", app)
-      run_cpl_command!("setup-app", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
+      run_cpflow_command!("setup-app", "-a", app)
     end
 
     it "successfully runs hook", :slow do
       result = nil
 
-      spawn_cpl_command("delete", "-a", app, "--yes") do |it|
+      spawn_cpflow_command("delete", "-a", app, "--yes") do |it|
         result = it.read_full_output
       end
 
@@ -273,13 +273,13 @@ describe Command::Delete do
     let!(:app) { dummy_test_app("valid-pre-deletion-hook") }
 
     before do
-      run_cpl_command!("setup-app", "-a", app)
+      run_cpflow_command!("setup-app", "-a", app)
     end
 
     it "does not run hook" do
       allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
 
-      result = run_cpl_command("delete", "-a", app, "--skip-pre-deletion-hook")
+      result = run_cpflow_command("delete", "-a", app, "--skip-pre-deletion-hook")
 
       expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -7,7 +7,7 @@ describe Command::DeployImage do
     let!(:app) { dummy_test_app("rails", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("deploy-image", "-a", app)
+      result = run_cpflow_command("deploy-image", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to match(/Image '#{app}:NO_IMAGE_AVAILABLE' does not exist/)
@@ -18,16 +18,16 @@ describe Command::DeployImage do
     let!(:app) { dummy_test_app }
 
     before do
-      run_cpl_command!("apply-template", "app", "-a", app)
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("apply-template", "app", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "raises error", :slow do
-      result = run_cpl_command("deploy-image", "-a", app)
+      result = run_cpflow_command("deploy-image", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'rails'")
@@ -38,7 +38,7 @@ describe Command::DeployImage do
     let!(:app) { dummy_test_app("rails-non-app-image", create_if_not_exists: true) }
 
     it "deploys latest image to app workloads", :slow do
-      result = run_cpl_command("deploy-image", "-a", app)
+      result = run_cpflow_command("deploy-image", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Running release script")
@@ -51,7 +51,7 @@ describe Command::DeployImage do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("deploy-image", "-a", app, "--run-release-phase")
+      result = run_cpflow_command("deploy-image", "-a", app, "--run-release-phase")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'release_script'")
@@ -66,19 +66,19 @@ describe Command::DeployImage do
 
       allow(Kernel).to receive(:sleep)
 
-      run_cpl_command!("apply-template", "app", "rails", "postgres", "-a", app)
-      run_cpl_command!("build-image", "-a", app)
-      run_cpl_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+      run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
+      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "fails to run release script and fails to deploy image", :slow do
       result = nil
 
-      spawn_cpl_command("deploy-image", "-a", app, "--run-release-phase") do |it|
+      spawn_cpflow_command("deploy-image", "-a", app, "--run-release-phase") do |it|
         result = it.read_full_output
       end
 
@@ -96,13 +96,13 @@ describe Command::DeployImage do
 
       allow(Kernel).to receive(:sleep)
 
-      run_cpl_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
     it "runs release script and deploys image", :slow do
       result = nil
 
-      spawn_cpl_command("deploy-image", "-a", app, "--run-release-phase") do |it|
+      spawn_cpflow_command("deploy-image", "-a", app, "--run-release-phase") do |it|
         result = it.read_full_output
       end
 

--- a/spec/command/doctor_spec.rb
+++ b/spec/command/doctor_spec.rb
@@ -13,7 +13,7 @@ describe Command::Doctor do
     it "fails if there are app names contained in others" do
       temporarily_switch_config_file("invalid-app-names")
 
-      result = run_cpl_command("doctor", "--validations", "config")
+      result = run_cpflow_command("doctor", "--validations", "config")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("[FAIL] config")
@@ -25,7 +25,7 @@ describe Command::Doctor do
     it "passes if there are no issues" do
       temporarily_switch_config_file("valid-app-names")
 
-      result = run_cpl_command("doctor", "--validations", "config")
+      result = run_cpflow_command("doctor", "--validations", "config")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("[PASS] config")
@@ -36,7 +36,7 @@ describe Command::Doctor do
     let!(:app) { dummy_test_app }
 
     it "raises error if app is not provided" do
-      result = run_cpl_command("doctor", "--validations", "templates")
+      result = run_cpflow_command("doctor", "--validations", "templates")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("App is required for templates validation")
@@ -45,7 +45,7 @@ describe Command::Doctor do
     it "fails if there are duplicate templates" do
       stub_template_filenames("app", "app-without-identity", "rails")
 
-      result = run_cpl_command("doctor", "--validations", "templates", "-a", app)
+      result = run_cpflow_command("doctor", "--validations", "templates", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("[FAIL] templates")
@@ -55,7 +55,7 @@ describe Command::Doctor do
     it "passes if there are no issues" do
       stub_template_filenames("app", "rails")
 
-      result = run_cpl_command("doctor", "--validations", "templates", "-a", app)
+      result = run_cpflow_command("doctor", "--validations", "templates", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("[PASS] templates")
@@ -65,7 +65,7 @@ describe Command::Doctor do
     it "warns about deprecated variables" do
       stub_template_filenames("app-with-deprecated-variables")
 
-      result = run_cpl_command("doctor", "--validations", "templates", "-a", app)
+      result = run_cpflow_command("doctor", "--validations", "templates", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("[PASS] templates")
@@ -79,7 +79,7 @@ describe Command::Doctor do
 
   context "when validation is not recognized" do
     it "raises error" do
-      result = run_cpl_command("doctor", "--validations", "unknown")
+      result = run_cpflow_command("doctor", "--validations", "unknown")
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Invalid value provided for option --validations")

--- a/spec/command/env_spec.rb
+++ b/spec/command/env_spec.rb
@@ -7,7 +7,7 @@ describe Command::Env do
     let!(:app) { dummy_test_app }
 
     it "raises error" do
-      result = run_cpl_command("env", "-a", app)
+      result = run_cpflow_command("env", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find app '#{app}'")
@@ -18,7 +18,7 @@ describe Command::Env do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "displays app-specific environment variables" do
-      result = run_cpl_command("env", "-a", app)
+      result = run_cpflow_command("env", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout])

--- a/spec/command/exists_spec.rb
+++ b/spec/command/exists_spec.rb
@@ -7,7 +7,7 @@ describe Command::Exists do
     let!(:app) { dummy_test_app }
 
     it "exits with non-zero status" do
-      result = run_cpl_command("exists", "-a", app)
+      result = run_cpflow_command("exists", "-a", app)
 
       expect(result[:status]).not_to eq(0)
     end
@@ -17,7 +17,7 @@ describe Command::Exists do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "exits with zero status" do
-      result = run_cpl_command("exists", "-a", app)
+      result = run_cpflow_command("exists", "-a", app)
 
       expect(result[:status]).to eq(0)
     end

--- a/spec/command/generate_spec.rb
+++ b/spec/command/generate_spec.rb
@@ -7,7 +7,7 @@ GEM_ROOT_PATH = Pathname.new(Dir.pwd)
 GEM_TEMP_PATH = GEM_ROOT_PATH.join("tmp")
 GENERATOR_PLAYGROUND_PATH = GEM_TEMP_PATH.join("sample-project")
 CONTROLPLANE_CONFIG_DIR_PATH = GENERATOR_PLAYGROUND_PATH.join(".controlplane")
-CPL_EXECUTABLE_PATH = GEM_ROOT_PATH.join("bin", "cpl")
+CPFLOW_EXECUTABLE_PATH = GEM_ROOT_PATH.join("bin", "cpflow")
 
 def inside_dir(path)
   original_working_dir = Dir.pwd
@@ -30,7 +30,7 @@ describe Command::Generate do
   context "when no configuration exist in the project" do
     it "generates base config files" do
       inside_dir(GENERATOR_PLAYGROUND_PATH) do
-        Cpl::Cli.start([described_class::NAME])
+        Cpflow::Cli.start([described_class::NAME])
         controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")
         expect(controlplane_config_file_path).to exist
       end
@@ -43,7 +43,7 @@ describe Command::Generate do
         Dir.mkdir(CONTROLPLANE_CONFIG_DIR_PATH)
 
         expect do
-          Cpl::Cli.start([described_class::NAME])
+          Cpflow::Cli.start([described_class::NAME])
         end.to output(/already exist/).to_stderr
 
         controlplane_config_file_path = CONTROLPLANE_CONFIG_DIR_PATH.join("controlplane.yml")

--- a/spec/command/info_spec.rb
+++ b/spec/command/info_spec.rb
@@ -17,12 +17,12 @@ describe Command::Info do
     it "does not include app" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app_prefix)
+      result = run_cpflow_command("info", "-a", app_prefix)
 
       expect(Shell).not_to have_received(:color)
         .with(include("Any app starting with '#{app_prefix}'"), :red)
       expect(result[:status]).to eq(0)
-      expect(result[:stdout]).not_to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).not_to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
   end
 
@@ -34,7 +34,7 @@ describe Command::Info do
     it "does not highlight anything for single app" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app1)
+      result = run_cpflow_command("info", "-a", app1)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with("rails", :red)
@@ -42,14 +42,14 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).not_to include("cpl setup-app")
-      expect(result[:stdout]).not_to include("cpl apply-template")
+      expect(result[:stdout]).not_to include("cpflow setup-app")
+      expect(result[:stdout]).not_to include("cpflow apply-template")
     end
 
     it "does not highlight anything for multiple apps" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app_prefix)
+      result = run_cpflow_command("info", "-a", app_prefix)
 
       expect(Shell).not_to have_received(:color)
         .with(include("Any app starting with '#{app_prefix}'"), :red)
@@ -58,8 +58,8 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).not_to include("cpl setup-app")
-      expect(result[:stdout]).not_to include("cpl apply-template")
+      expect(result[:stdout]).not_to include("cpflow setup-app")
+      expect(result[:stdout]).not_to include("cpflow apply-template")
     end
   end
 
@@ -71,7 +71,7 @@ describe Command::Info do
     it "highlights single app with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app1)
+      result = run_cpflow_command("info", "-a", app1)
 
       expect(Shell).to have_received(:color).with(app1, :red)
       expect(Shell).to have_received(:color).with("rails", :red)
@@ -79,13 +79,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl setup-app -a #{app1}`")
+      expect(result[:stdout]).to include("`cpflow setup-app -a #{app1}`")
     end
 
     it "highlights multiple apps with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app_prefix)
+      result = run_cpflow_command("info", "-a", app_prefix)
 
       expect(Shell).to have_received(:color)
         .with(include("Any app starting with '#{app_prefix}'"), :red)
@@ -94,13 +94,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).not_to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
 
     it "highlights apps for single org with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-o", dummy_test_org)
+      result = run_cpflow_command("info", "-o", dummy_test_org)
 
       expect(Shell).to have_received(:color)
         .with(include("Any app starting with '#{app_prefix}'"), :red)
@@ -109,13 +109,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).not_to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
 
     it "highlights apps for multiple orgs with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info")
+      result = run_cpflow_command("info")
 
       expect(Shell).to have_received(:color)
         .with(include("Any app starting with '#{app_prefix}'"), :red)
@@ -124,7 +124,7 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).not_to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
   end
 
@@ -136,7 +136,7 @@ describe Command::Info do
     it "highlights workloads for single app with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app1)
+      result = run_cpflow_command("info", "-a", app1)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with("rails", :red)
@@ -144,13 +144,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app1}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app1}`")
     end
 
     it "highlights workloads for multiple apps with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app_prefix)
+      result = run_cpflow_command("info", "-a", app_prefix)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -158,14 +158,14 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app1}`")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app2}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app1}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app2}`")
     end
 
     it "highlights workloads for single org with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-o", dummy_test_org)
+      result = run_cpflow_command("info", "-o", dummy_test_org)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -173,14 +173,14 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app1}`")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app2}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app1}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app2}`")
     end
 
     it "highlights workloads for multiple orgs with red" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info")
+      result = run_cpflow_command("info")
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -188,8 +188,8 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app1}`")
-      expect(result[:stdout]).to include("`cpl apply-template postgres -a #{app2}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app1}`")
+      expect(result[:stdout]).to include("`cpflow apply-template postgres -a #{app2}`")
     end
   end
 
@@ -201,7 +201,7 @@ describe Command::Info do
     it "highlights workloads for single app with green" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app1)
+      result = run_cpflow_command("info", "-a", app1)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with("rails", :red)
@@ -210,14 +210,14 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).not_to include("- #{app2}")
-      expect(result[:stdout]).not_to include("cpl setup-app")
-      expect(result[:stdout]).not_to include("cpl apply-template")
+      expect(result[:stdout]).not_to include("cpflow setup-app")
+      expect(result[:stdout]).not_to include("cpflow apply-template")
     end
 
     it "highlights workloads for multiple apps with green" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-a", app_prefix)
+      result = run_cpflow_command("info", "-a", app_prefix)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -225,13 +225,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).not_to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).not_to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
 
     it "highlights workloads for single org with green" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info", "-o", dummy_test_org)
+      result = run_cpflow_command("info", "-o", dummy_test_org)
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -239,13 +239,13 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).not_to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).not_to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
 
     it "highlights workloads for multiple orgs with green" do
       allow(Shell).to receive(:color).and_call_original
 
-      result = run_cpl_command("info")
+      result = run_cpflow_command("info")
 
       expect(Shell).not_to have_received(:color).with(app1, :red)
       expect(Shell).not_to have_received(:color).with(app2, :red)
@@ -253,7 +253,7 @@ describe Command::Info do
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("- #{app1}")
       expect(result[:stdout]).to include("- #{app2}")
-      expect(result[:stdout]).not_to include("`cpl setup-app -a #{app_prefix}-whatever`")
+      expect(result[:stdout]).not_to include("`cpflow setup-app -a #{app_prefix}-whatever`")
     end
   end
 end

--- a/spec/command/latest_image_spec.rb
+++ b/spec/command/latest_image_spec.rb
@@ -7,7 +7,7 @@ describe Command::LatestImage do
     let!(:app) { dummy_test_app }
 
     it "displays default image for app" do
-      result = run_cpl_command("latest-image", "-a", app)
+      result = run_cpflow_command("latest-image", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("#{app}:NO_IMAGE_AVAILABLE")
@@ -18,7 +18,7 @@ describe Command::LatestImage do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     it "displays latest image for app" do
-      result = run_cpl_command("latest-image", "-a", app)
+      result = run_cpflow_command("latest-image", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("#{app}:2")

--- a/spec/command/logs_spec.rb
+++ b/spec/command/logs_spec.rb
@@ -7,7 +7,7 @@ describe Command::Logs do
   let!(:message_regex) { /Fetching logs .+?\n/ }
 
   before do
-    run_cpl_command!("ps:start", "-a", app, "--wait")
+    run_cpflow_command!("ps:start", "-a", app, "--wait")
   end
 
   context "when no workload is provided" do
@@ -16,7 +16,7 @@ describe Command::Logs do
       logs_result = nil
       logs_regex = /Rails .+? application starting in production/
 
-      spawn_cpl_command("logs", "-a", app) do |it|
+      spawn_cpflow_command("logs", "-a", app) do |it|
         message_result = it.wait_for(message_regex)
         logs_result = it.wait_for(logs_regex)
         it.kill
@@ -33,7 +33,7 @@ describe Command::Logs do
       logs_result = nil
       logs_regex = /PostgreSQL init process complete/
 
-      spawn_cpl_command("logs", "-a", app, "--workload", "postgres") do |it|
+      spawn_cpflow_command("logs", "-a", app, "--workload", "postgres") do |it|
         message_result = it.wait_for(message_regex)
         logs_result = it.wait_for(logs_regex)
         it.kill
@@ -46,10 +46,10 @@ describe Command::Logs do
 
   context "when replica is provided" do
     let!(:replica) do
-      run_cpl_command!("ps:stop", "-a", app, "--wait")
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:stop", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
 
-      result = run_cpl_command!("ps", "-a", app, "--workload", "postgres")
+      result = run_cpflow_command!("ps", "-a", app, "--workload", "postgres")
       result[:stdout].strip
     end
 
@@ -58,7 +58,7 @@ describe Command::Logs do
       logs_result = nil
       logs_regex = /PostgreSQL init process complete/
 
-      spawn_cpl_command("logs", "-a", app, "--workload", "postgres", "--replica", replica) do |it|
+      spawn_cpflow_command("logs", "-a", app, "--workload", "postgres", "--replica", replica) do |it|
         message_result = it.wait_for(message_regex)
         logs_result = it.wait_for(logs_regex)
         it.kill
@@ -79,7 +79,7 @@ describe Command::Logs do
       result = nil
       expected_regex = /Line \d+/
 
-      spawn_cpl_command("logs", "-a", app, "--workload", workload, "--limit", "5") do |it|
+      spawn_cpflow_command("logs", "-a", app, "--workload", workload, "--limit", "5") do |it|
         result = it.wait_for(expected_regex)
         it.kill
       end
@@ -102,7 +102,7 @@ describe Command::Logs do
       result = nil
       expected_regex = /Line \d+/
 
-      spawn_cpl_command("logs", "-a", app, "--workload", workload, "--since", "30s") do |it|
+      spawn_cpflow_command("logs", "-a", app, "--workload", workload, "--since", "30s") do |it|
         result = it.wait_for(expected_regex)
         it.kill
       end
@@ -115,7 +115,7 @@ describe Command::Logs do
     runner_workload = nil
 
     runner_workload_regex = /runner workload '(.+?)'/
-    spawn_cpl_command("run", "-a", app, "--detached", "--", cmd) do |it|
+    spawn_cpflow_command("run", "-a", app, "--detached", "--", cmd) do |it|
       runner_workload_result = it.wait_for(runner_workload_regex)
       runner_workload = runner_workload_result.match(runner_workload_regex)[1]
     end

--- a/spec/command/maintenance_off_spec.rb
+++ b/spec/command/maintenance_off_spec.rb
@@ -7,7 +7,7 @@ describe Command::MaintenanceOff do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("maintenance:off", "-a", app)
+      result = run_cpflow_command("maintenance:off", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find domain")
@@ -18,7 +18,7 @@ describe Command::MaintenanceOff do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("maintenance:off", "-a", app)
+      result = run_cpflow_command("maintenance:off", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'maintenance'")
@@ -31,20 +31,20 @@ describe Command::MaintenanceOff do
     before do
       allow(Kernel).to receive(:sleep)
 
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
     end
 
     it "does nothing if maintenance mode is already disabled", :slow do
-      run_cpl_command!("maintenance:off", "-a", app)
-      result = run_cpl_command("maintenance:off", "-a", app)
+      run_cpflow_command!("maintenance:off", "-a", app)
+      result = run_cpflow_command("maintenance:off", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Maintenance mode is already disabled for app '#{app}'")
     end
 
     it "disables maintenance mode", :slow do
-      run_cpl_command!("maintenance:on", "-a", app)
-      result = run_cpl_command("maintenance:off", "-a", app)
+      run_cpflow_command!("maintenance:on", "-a", app)
+      result = run_cpflow_command("maintenance:off", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Maintenance mode disabled for app '#{app}'")

--- a/spec/command/maintenance_on_spec.rb
+++ b/spec/command/maintenance_on_spec.rb
@@ -7,7 +7,7 @@ describe Command::MaintenanceOn do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("maintenance:on", "-a", app)
+      result = run_cpflow_command("maintenance:on", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find domain")
@@ -18,7 +18,7 @@ describe Command::MaintenanceOn do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("maintenance:on", "-a", app)
+      result = run_cpflow_command("maintenance:on", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'maintenance'")
@@ -31,20 +31,20 @@ describe Command::MaintenanceOn do
     before do
       allow(Kernel).to receive(:sleep)
 
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
     end
 
     it "does nothing if maintenance mode is already enabled", :slow do
-      run_cpl_command!("maintenance:on", "-a", app)
-      result = run_cpl_command("maintenance:on", "-a", app)
+      run_cpflow_command!("maintenance:on", "-a", app)
+      result = run_cpflow_command("maintenance:on", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Maintenance mode is already enabled for app '#{app}'")
     end
 
     it "enables maintenance mode", :slow do
-      run_cpl_command!("maintenance:off", "-a", app)
-      result = run_cpl_command("maintenance:on", "-a", app)
+      run_cpflow_command!("maintenance:off", "-a", app)
+      result = run_cpflow_command("maintenance:on", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Maintenance mode enabled for app '#{app}'")

--- a/spec/command/maintenance_set_page_spec.rb
+++ b/spec/command/maintenance_set_page_spec.rb
@@ -9,7 +9,7 @@ describe Command::MaintenanceSetPage do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("maintenance:set-page", example_maintenance_page, "-a", app)
+      result = run_cpflow_command("maintenance:set-page", example_maintenance_page, "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'maintenance'")
@@ -20,15 +20,15 @@ describe Command::MaintenanceSetPage do
     let!(:app) { dummy_test_app("external-maintenance-image") }
 
     before do
-      run_cpl_command!("apply-template", "app", "maintenance-with-external-image", "-a", app)
+      run_cpflow_command!("apply-template", "app", "maintenance-with-external-image", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "does nothing" do
-      result = run_cpl_command("maintenance:set-page", example_maintenance_page, "-a", app)
+      result = run_cpflow_command("maintenance:set-page", example_maintenance_page, "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Setting '#{example_maintenance_page}' as the page for maintenance mode")
@@ -39,7 +39,7 @@ describe Command::MaintenanceSetPage do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     it "sets page for maintenance mode" do
-      result = run_cpl_command("maintenance:set-page", example_maintenance_page, "-a", app)
+      result = run_cpflow_command("maintenance:set-page", example_maintenance_page, "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr])

--- a/spec/command/maintenance_spec.rb
+++ b/spec/command/maintenance_spec.rb
@@ -7,7 +7,7 @@ describe Command::Maintenance do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("maintenance", "-a", app)
+      result = run_cpflow_command("maintenance", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find domain")
@@ -20,20 +20,20 @@ describe Command::Maintenance do
     before do
       allow(Kernel).to receive(:sleep)
 
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
     end
 
     it "displays 'off' if maintenance mode is disabled", :slow do
-      run_cpl_command!("maintenance:off", "-a", app)
-      result = run_cpl_command("maintenance", "-a", app)
+      run_cpflow_command!("maintenance:off", "-a", app)
+      result = run_cpflow_command("maintenance", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("off")
     end
 
     it "displays 'on' if maintenance mode is enabled", :slow do
-      run_cpl_command!("maintenance:on", "-a", app)
-      result = run_cpl_command("maintenance", "-a", app)
+      run_cpflow_command!("maintenance:on", "-a", app)
+      result = run_cpflow_command("maintenance", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("on")

--- a/spec/command/no_command_spec.rb
+++ b/spec/command/no_command_spec.rb
@@ -5,19 +5,19 @@ require "spec_helper"
 describe Command::NoCommand do
   context "when called with nothing" do
     it "displays help" do
-      result = run_cpl_command
+      result = run_cpflow_command
 
       expect(result[:status]).to eq(0)
-      expect(result[:stdout]).to include("cpl commands")
+      expect(result[:stdout]).to include("cpflow commands")
     end
   end
 
   context "when called with --version" do
     it "displays version" do
-      result = run_cpl_command("--version")
+      result = run_cpflow_command("--version")
 
       expect(result[:status]).to eq(0)
-      expect(result[:stdout]).to include(Cpl::VERSION)
+      expect(result[:stdout]).to include(Cpflow::VERSION)
     end
   end
 end

--- a/spec/command/open_console_spec.rb
+++ b/spec/command/open_console_spec.rb
@@ -9,7 +9,7 @@ describe Command::OpenConsole do
     it "opens app console on Control Plane" do
       allow(Kernel).to receive(:exec)
 
-      result = run_cpl_command("open-console", "-a", app)
+      result = run_cpflow_command("open-console", "-a", app)
 
       expected_url = %r{https://console.cpln.io/console/org/.+?/gvc/#{app}/-info}
       expect(Kernel).to have_received(:exec).with(anything, match(expected_url))
@@ -21,7 +21,7 @@ describe Command::OpenConsole do
     it "opens workload page on Control Plane" do
       allow(Kernel).to receive(:exec)
 
-      result = run_cpl_command("open-console", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("open-console", "-a", app, "--workload", "rails")
 
       expected_url = %r{https://console.cpln.io/console/org/.+?/gvc/#{app}/workload/rails/-info}
       expect(Kernel).to have_received(:exec).with(anything, match(expected_url))

--- a/spec/command/open_spec.rb
+++ b/spec/command/open_spec.rb
@@ -7,7 +7,7 @@ describe Command::Open do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("open", "-a", app)
+      result = run_cpflow_command("open", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'rails'")
@@ -20,7 +20,7 @@ describe Command::Open do
     it "opens endpoint of one-off workload" do
       allow(Kernel).to receive(:exec)
 
-      result = run_cpl_command("open", "-a", app)
+      result = run_cpflow_command("open", "-a", app)
 
       expected_url = %r{https://rails-.+?.cpln.app}
       expect(Kernel).to have_received(:exec).with(anything, match(expected_url))
@@ -34,7 +34,7 @@ describe Command::Open do
     it "opens endpoint of specific workload" do
       allow(Kernel).to receive(:exec)
 
-      result = run_cpl_command("open", "-a", app, "--workload", "postgres")
+      result = run_cpflow_command("open", "-a", app, "--workload", "postgres")
 
       expected_url = %r{https://postgres-.+?.cpln.app}
       expect(Kernel).to have_received(:exec).with(anything, match(expected_url))

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -13,18 +13,18 @@ describe Command::PromoteAppFromUpstream do
       # Ideally, we should have a different org, but for testing purposes, this works
       ENV["CPLN_ORG_UPSTREAM"] = dummy_test_org
 
-      run_cpl_command!("apply-template", "app", "-a", upstream_app)
-      run_cpl_command!("apply-template", "app", "rails", "-a", app)
-      run_cpl_command!("build-image", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+      run_cpflow_command!("build-image", "-a", upstream_app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", upstream_app, "--yes")
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "copies latest image from upstream, skips release script and deploys image", :slow do
-      result = run_cpl_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
+      result = run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
@@ -45,21 +45,21 @@ describe Command::PromoteAppFromUpstream do
       ENV["CPLN_ORG_UPSTREAM"] = dummy_test_org
       ENV["APP_NAME"] = app
 
-      run_cpl_command!("apply-template", "app", "-a", upstream_app)
-      run_cpl_command!("apply-template", "app", "rails", "postgres", "-a", app)
-      run_cpl_command!("build-image", "-a", upstream_app)
-      run_cpl_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
+      run_cpflow_command!("build-image", "-a", upstream_app)
+      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
     after do
-      run_cpl_command!("delete", "-a", upstream_app, "--yes")
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "copies latest image from upstream, fails to run release script and fails to deploy image", :slow do
       result = nil
 
-      spawn_cpl_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
+      spawn_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
         result = it.read_full_output
       end
 
@@ -82,21 +82,21 @@ describe Command::PromoteAppFromUpstream do
       ENV["CPLN_ORG_UPSTREAM"] = dummy_test_org
       ENV["APP_NAME"] = app
 
-      run_cpl_command!("apply-template", "app", "-a", upstream_app)
-      run_cpl_command!("apply-template", "app", "rails", "postgres", "-a", app)
-      run_cpl_command!("build-image", "-a", upstream_app)
-      run_cpl_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+      run_cpflow_command!("apply-template", "app", "-a", upstream_app)
+      run_cpflow_command!("apply-template", "app", "rails", "postgres", "-a", app)
+      run_cpflow_command!("build-image", "-a", upstream_app)
+      run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
     end
 
     after do
-      run_cpl_command!("delete", "-a", upstream_app, "--yes")
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", upstream_app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "copies latest image from upstream, runs release script and deploys image", :slow do
       result = nil
 
-      spawn_cpl_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
+      spawn_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
         result = it.read_full_output
       end
 

--- a/spec/command/ps_restart_spec.rb
+++ b/spec/command/ps_restart_spec.rb
@@ -7,7 +7,7 @@ describe Command::PsRestart do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("ps:restart", "-a", app)
+      result = run_cpflow_command("ps:restart", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'rails'")
@@ -18,11 +18,11 @@ describe Command::PsRestart do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     before do
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
     end
 
     it "restarts all workloads", :slow do
-      result = run_cpl_command("ps:restart", "-a", app)
+      result = run_cpflow_command("ps:restart", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Restarting workload 'rails'[.]+? done!/)
@@ -30,7 +30,7 @@ describe Command::PsRestart do
     end
 
     it "restarts specific workload", :slow do
-      result = run_cpl_command("ps:restart", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("ps:restart", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Restarting workload 'rails'[.]+? done!/)

--- a/spec/command/ps_spec.rb
+++ b/spec/command/ps_spec.rb
@@ -7,7 +7,7 @@ describe Command::Ps do
     let!(:app) { dummy_test_app }
 
     it "raises error" do
-      result = run_cpl_command("ps", "-a", app)
+      result = run_cpflow_command("ps", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find app '#{app}'")
@@ -18,7 +18,7 @@ describe Command::Ps do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("ps", "-a", app)
+      result = run_cpflow_command("ps", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'rails'")
@@ -29,12 +29,12 @@ describe Command::Ps do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     before do
-      run_cpl_command!("ps:start", "-a", app, "--wait")
-      run_cpl_command!("ps:stop", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:stop", "-a", app, "--wait")
     end
 
     it "displays nothing", :slow do
-      result = run_cpl_command("ps", "-a", app)
+      result = run_cpflow_command("ps", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to be_empty
@@ -45,11 +45,11 @@ describe Command::Ps do
     let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
     before do
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
     end
 
     it "displays currently running replicas for all workloads", :slow do
-      result = run_cpl_command("ps", "-a", app)
+      result = run_cpflow_command("ps", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("rails-")
@@ -57,7 +57,7 @@ describe Command::Ps do
     end
 
     it "displays currently running replicas for specific workload", :slow do
-      result = run_cpl_command("ps", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("ps", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
       expect(result[:stdout]).to include("rails-")

--- a/spec/command/ps_start_spec.rb
+++ b/spec/command/ps_start_spec.rb
@@ -6,11 +6,11 @@ describe Command::PsStart do
   let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
   before do
-    run_cpl_command!("ps:stop", "-a", app, "--wait")
+    run_cpflow_command!("ps:stop", "-a", app, "--wait")
   end
 
   it "starts all workloads", :slow do
-    result = run_cpl_command("ps:start", "-a", app)
+    result = run_cpflow_command("ps:start", "-a", app)
 
     expect(result[:status]).to eq(0)
     expect(result[:stderr]).to match(/Starting workload 'rails'[.]+? done!/)
@@ -18,7 +18,7 @@ describe Command::PsStart do
   end
 
   it "starts specific workload", :slow do
-    result = run_cpl_command("ps:start", "-a", app, "--workload", "rails")
+    result = run_cpflow_command("ps:start", "-a", app, "--workload", "rails")
 
     expect(result[:status]).to eq(0)
     expect(result[:stderr]).to match(/Starting workload 'rails'[.]+? done!/)
@@ -26,7 +26,7 @@ describe Command::PsStart do
   end
 
   it "starts all workloads and waits for them to be ready", :slow do
-    result = run_cpl_command("ps:start", "-a", app, "--wait")
+    result = run_cpflow_command("ps:start", "-a", app, "--wait")
 
     expect(result[:status]).to eq(0)
     expect(result[:stderr]).to match(/Starting workload 'rails'[.]+? done!/)

--- a/spec/command/ps_stop_spec.rb
+++ b/spec/command/ps_stop_spec.rb
@@ -6,12 +6,12 @@ describe Command::PsStop do
   let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
   before do
-    run_cpl_command!("ps:start", "-a", app, "--wait")
+    run_cpflow_command!("ps:start", "-a", app, "--wait")
   end
 
   context "when no workload is provided" do
     it "stops all workloads", :slow do
-      result = run_cpl_command("ps:stop", "-a", app)
+      result = run_cpflow_command("ps:stop", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Stopping workload 'rails'[.]+? done!/)
@@ -19,7 +19,7 @@ describe Command::PsStop do
     end
 
     it "stops all workloads and waits for them to not be ready", :slow do
-      result = run_cpl_command("ps:stop", "-a", app, "--wait")
+      result = run_cpflow_command("ps:stop", "-a", app, "--wait")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Stopping workload 'rails'[.]+? done!/)
@@ -31,7 +31,7 @@ describe Command::PsStop do
 
   context "when workload is provided" do
     it "stops specific workload", :slow do
-      result = run_cpl_command("ps:stop", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("ps:stop", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Stopping workload 'rails'[.]+? done!/)
@@ -41,22 +41,22 @@ describe Command::PsStop do
 
   context "when replica is provided" do
     let!(:replica) do
-      run_cpl_command!("ps:stop", "-a", app, "--wait")
-      run_cpl_command!("ps:start", "-a", app, "--wait")
+      run_cpflow_command!("ps:stop", "-a", app, "--wait")
+      run_cpflow_command!("ps:start", "-a", app, "--wait")
 
-      result = run_cpl_command!("ps", "-a", app, "--workload", "rails")
+      result = run_cpflow_command!("ps", "-a", app, "--workload", "rails")
       result[:stdout].strip
     end
 
     it "stops specific replica", :slow do
-      result = run_cpl_command("ps:stop", "-a", app, "--workload", "rails", "--replica", replica)
+      result = run_cpflow_command("ps:stop", "-a", app, "--workload", "rails", "--replica", replica)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Stopping replica '#{replica}'[.]+? done!/)
     end
 
     it "stops specific replica and waits for it to not be ready", :slow do
-      result = run_cpl_command("ps:stop", "-a", app, "--workload", "rails", "--replica", replica, "--wait")
+      result = run_cpflow_command("ps:stop", "-a", app, "--workload", "rails", "--replica", replica, "--wait")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Stopping replica '#{replica}'[.]+? done!/)

--- a/spec/command/ps_wait_spec.rb
+++ b/spec/command/ps_wait_spec.rb
@@ -6,13 +6,13 @@ describe Command::PsWait do
   let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
   before do
-    run_cpl_command!("ps:start", "-a", app, "--wait")
-    run_cpl_command!("ps:restart", "-a", app)
+    run_cpflow_command!("ps:start", "-a", app, "--wait")
+    run_cpflow_command!("ps:restart", "-a", app)
   end
 
   context "when no workloads are suspended" do
     it "waits for all workloads to be ready", :slow do
-      result = run_cpl_command("ps:wait", "-a", app)
+      result = run_cpflow_command("ps:wait", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
@@ -20,7 +20,7 @@ describe Command::PsWait do
     end
 
     it "waits for specific workload to be ready", :slow do
-      result = run_cpl_command("ps:wait", "-a", app, "--workload", "rails")
+      result = run_cpflow_command("ps:wait", "-a", app, "--workload", "rails")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Waiting for workload 'rails' to be ready[.]+? done!/)
@@ -30,11 +30,11 @@ describe Command::PsWait do
 
   context "when some workloads are suspended" do
     before do
-      run_cpl_command!("ps:stop", "-a", app, "--workload", "rails")
+      run_cpflow_command!("ps:stop", "-a", app, "--workload", "rails")
     end
 
     it "skips suspended workloads", :slow do
-      result = run_cpl_command("ps:wait", "-a", app)
+      result = run_cpflow_command("ps:wait", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Workload 'rails' is suspended")

--- a/spec/command/run_spec.rb
+++ b/spec/command/run_spec.rb
@@ -7,7 +7,7 @@ describe Command::Run do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("run", "-a", app)
+      result = run_cpflow_command("run", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find workload 'rails'")
@@ -19,14 +19,14 @@ describe Command::Run do
       let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
       before do
-        run_cpl_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
+        run_cpflow_command!("ps:start", "-a", app, "--workload", "postgres", "--wait")
       end
 
       it "clones workload and runs provided command", :slow do
         result = nil
         expected_regex = /Gemfile/
 
-        spawn_cpl_command("run", "-a", app, "--interactive", "--", "bash") do |it|
+        spawn_cpflow_command("run", "-a", app, "--interactive", "--", "bash") do |it|
           it.wait_for_prompt
           it.type("ls")
           result = it.wait_for(expected_regex)
@@ -41,20 +41,20 @@ describe Command::Run do
       let!(:app) { dummy_test_app("fix-terminal-size") }
 
       before do
-        run_cpl_command!("apply-template", "app", "rails", "-a", app)
-        run_cpl_command!("build-image", "-a", app)
-        run_cpl_command!("deploy-image", "-a", app)
+        run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+        run_cpflow_command!("build-image", "-a", app)
+        run_cpflow_command!("deploy-image", "-a", app)
       end
 
       after do
-        run_cpl_command!("delete", "-a", app, "--yes")
+        run_cpflow_command!("delete", "-a", app, "--yes")
       end
 
       it "clones workload and runs with fixed terminal size", :slow do
         result = nil
         expected_regex = /10 150/
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "bash", stty_rows: 10, stty_cols: 150) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "bash", stty_rows: 10, stty_cols: 150) do |it|
           it.wait_for_prompt
           it.type("stty size")
           result = it.wait_for(expected_regex)
@@ -72,7 +72,7 @@ describe Command::Run do
         result = nil
         expected_regex = /20 300/
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "bash", "--terminal-size", "20,300") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "bash", "--terminal-size", "20,300") do |it|
           it.wait_for_prompt
           it.type("stty size")
           result = it.wait_for(expected_regex)
@@ -91,7 +91,7 @@ describe Command::Run do
       it "clones workload and runs provided command with success", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "ls") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "ls") do |it|
           result = it.read_full_output
         end
 
@@ -103,7 +103,7 @@ describe Command::Run do
       it "clones workload and runs provided command with failure", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "nonexistent") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "nonexistent") do |it|
           result = it.read_full_output
         end
 
@@ -114,7 +114,7 @@ describe Command::Run do
       it "waits for job to finish", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "'sleep 10; ls'") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "'sleep 10; ls'") do |it|
           result = it.read_full_output
         end
 
@@ -129,24 +129,24 @@ describe Command::Run do
       let!(:cmd) { "'echo $CPLN_IMAGE'" }
 
       before do
-        run_cpl_command!("apply-template", "app", "rails", "-a", app)
-        run_cpl_command!("build-image", "-a", app)
-        run_cpl_command!("deploy-image", "-a", app)
-        run_cpl_command!("build-image", "-a", app)
+        run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+        run_cpflow_command!("build-image", "-a", app)
+        run_cpflow_command!("deploy-image", "-a", app)
+        run_cpflow_command!("build-image", "-a", app)
       end
 
       after do
-        run_cpl_command!("delete", "-a", app, "--yes")
+        run_cpflow_command!("delete", "-a", app, "--yes")
       end
 
       it "clones workload and runs with exact same image as original workload after running with latest image", :slow do
         result1 = nil
         result2 = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
           result1 = it.read_full_output
         end
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
           result2 = it.read_full_output
         end
 
@@ -162,7 +162,7 @@ describe Command::Run do
       it "clones workload and runs with latest image", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
           result = it.read_full_output
         end
 
@@ -172,7 +172,7 @@ describe Command::Run do
       it "clones workload and runs with specific image", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--image", "#{app}:1", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "#{app}:1", "--", cmd) do |it|
           result = it.read_full_output
         end
 
@@ -188,7 +188,7 @@ describe Command::Run do
       it "clones workload and runs with remote token", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
           result = it.read_full_output
         end
 
@@ -198,7 +198,7 @@ describe Command::Run do
       it "clones workload and runs with local token", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--use-local-token", "--", cmd) do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--use-local-token", "--", cmd) do |it|
           result = it.read_full_output
         end
 
@@ -210,19 +210,19 @@ describe Command::Run do
       let!(:app) { dummy_test_app("runner-job-timeout") }
 
       before do
-        run_cpl_command!("apply-template", "app", "rails", "-a", app)
-        run_cpl_command!("build-image", "-a", app)
-        run_cpl_command!("deploy-image", "-a", app)
+        run_cpflow_command!("apply-template", "app", "rails", "-a", app)
+        run_cpflow_command!("build-image", "-a", app)
+        run_cpflow_command!("deploy-image", "-a", app)
       end
 
       after do
-        run_cpl_command!("delete", "-a", app, "--yes")
+        run_cpflow_command!("delete", "-a", app, "--yes")
       end
 
       it "clones workload and times out before finishing", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", "'sleep 100; ls'") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "'sleep 100; ls'") do |it|
           result = it.read_full_output
         end
 
@@ -236,12 +236,12 @@ describe Command::Run do
       it "prints commands to log and stop the job", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--detached", "--", "ls") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--detached", "--", "ls") do |it|
           result = it.read_full_output
         end
 
-        expect(result).to include("cpl logs")
-        expect(result).to include("cpl ps:stop")
+        expect(result).to include("cpflow logs")
+        expect(result).to include("cpflow ps:stop")
       end
     end
 
@@ -249,17 +249,17 @@ describe Command::Run do
       let!(:app) { dummy_test_app("rails-env", create_if_not_exists: true) }
 
       before do
-        run_cpl_command!("apply-template", "rails-runner-with-non-default-values", "-a", app)
+        run_cpflow_command!("apply-template", "rails-runner-with-non-default-values", "-a", app)
       end
 
       after do
-        run_cpl_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
+        run_cpflow_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
       end
 
       it "updates runner workload", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
           result = it.read_full_output
         end
 
@@ -272,17 +272,17 @@ describe Command::Run do
       let!(:app) { dummy_test_app("rails-env", create_if_not_exists: true) }
 
       before do
-        run_cpl_command!("apply-template", "rails-runner-with-different-env", "-a", app)
+        run_cpflow_command!("apply-template", "rails-runner-with-different-env", "-a", app)
       end
 
       after do
-        run_cpl_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
+        run_cpflow_command!("delete", "-a", app, "--workload", "rails-runner", "--yes")
       end
 
       it "updates runner workload", :slow do
         result = nil
 
-        spawn_cpl_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
+        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
           result = it.read_full_output
         end
 

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -7,7 +7,7 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("nothing") }
 
     it "raises error" do
-      result = run_cpl_command("setup-app", "-a", app)
+      result = run_cpflow_command("setup-app", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("Can't find option 'setup_app_templates'")
@@ -18,7 +18,7 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("default", create_if_not_exists: true) }
 
     it "raises error" do
-      result = run_cpl_command("setup-app", "-a", app)
+      result = run_cpflow_command("setup-app", "-a", app)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("App '#{app}' already exists")
@@ -29,11 +29,11 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app }
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "applies templates from 'setup_app_templates'" do
-      result = run_cpl_command("setup-app", "-a", app, "--skip-secrets-setup")
+      result = run_cpflow_command("setup-app", "-a", app, "--skip-secrets-setup")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("Created items")
@@ -46,7 +46,7 @@ describe Command::SetupApp do
     end
 
     it "works with deprecated --skip-secret-access-binding name" do
-      result = run_cpl_command("setup-app", "-a", app, "--skip-secret-access-binding")
+      result = run_cpflow_command("setup-app", "-a", app, "--skip-secret-access-binding")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("DEPRECATED: Option --skip-secret-access-binding is deprecated")
@@ -60,7 +60,7 @@ describe Command::SetupApp do
     let!(:app_secrets_policy) { "#{app_secrets}-policy" }
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
 
       api = ControlplaneApi.new
       api.delete_secret(org: dummy_test_org, secret: app_secrets)
@@ -68,7 +68,7 @@ describe Command::SetupApp do
     end
 
     it "creates secret and policy, and binds identity to policy" do
-      result = run_cpl_command("setup-app", "-a", app)
+      result = run_cpflow_command("setup-app", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Creating secret '#{app_secrets}'[.]+? done!/)
@@ -82,11 +82,11 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("nonexistent-identity") }
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "creates identity, and binds identity to policy" do
-      result = run_cpl_command("setup-app", "-a", app)
+      result = run_cpflow_command("setup-app", "-a", app)
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to include("[identity] #{app}-identity")
@@ -101,17 +101,17 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("invalid-post-creation-hook") }
 
     before do
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "fails to run hook", :slow do
       result = nil
 
-      spawn_cpl_command("setup-app", "-a", app) do |it|
+      spawn_cpflow_command("setup-app", "-a", app) do |it|
         result = it.read_full_output
       end
 
@@ -124,17 +124,17 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("valid-post-creation-hook") }
 
     before do
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "successfully runs hook", :slow do
       result = nil
 
-      spawn_cpl_command("setup-app", "-a", app) do |it|
+      spawn_cpflow_command("setup-app", "-a", app) do |it|
         result = it.read_full_output
       end
 
@@ -147,11 +147,11 @@ describe Command::SetupApp do
     let!(:app) { dummy_test_app("valid-post-creation-hook") }
 
     after do
-      run_cpl_command!("delete", "-a", app, "--yes")
+      run_cpflow_command!("delete", "-a", app, "--yes")
     end
 
     it "does not run hook" do
-      result = run_cpl_command("setup-app", "-a", app, "--skip-post-creation-hook")
+      result = run_cpflow_command("setup-app", "-a", app, "--skip-post-creation-hook")
 
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Running post-creation hook")

--- a/spec/command/version_spec.rb
+++ b/spec/command/version_spec.rb
@@ -4,9 +4,9 @@ require "spec_helper"
 
 describe Command::Version do
   it "displays version" do
-    result = run_cpl_command("version")
+    result = run_cpflow_command("version")
 
     expect(result[:status]).to eq(0)
-    expect(result[:stdout]).to include(Cpl::VERSION)
+    expect(result[:stdout]).to include(Cpflow::VERSION)
   end
 end

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -6,14 +6,14 @@ options_by_key_name = Command::Base.all_options_by_key_name
 non_boolean_options_by_key_name = options_by_key_name
                                   .reject { |_, option| option[:params][:type] == :boolean }
 
-describe Cpl do
+describe Cpflow do
   it "has a version number" do
-    expect(Cpl::VERSION).not_to be_nil
+    expect(Cpflow::VERSION).not_to be_nil
   end
 
   non_boolean_options_by_key_name.each do |option_key_name, option|
     it "raises error if no value is provided for '#{option_key_name}' option" do
-      result = run_cpl_command("test", option_key_name)
+      result = run_cpflow_command("test", option_key_name)
 
       expect(result[:status]).not_to eq(0)
       expect(result[:stderr]).to include("No value provided for option --#{option[:name].to_s.tr('_', '-')}")

--- a/spec/dummy/.controlplane/controlplane.yml
+++ b/spec/dummy/.controlplane/controlplane.yml
@@ -20,7 +20,7 @@ apps:
     stale_app_image_deployed_days: 30
     upstream: dummy-test-upstream
     release_script: release.sh
-    default_domain: cpl.rafaelgomes.xyz
+    default_domain: cpflow.rafaelgomes.xyz
     maintenance_workload: maintenance
     setup_app_templates:
       - app
@@ -36,7 +36,7 @@ apps:
     <<: *common
 
     match_if_app_name_starts_with: true
-    default_domain: cpl.rafaelgomes.xyz
+    default_domain: cpflow.rafaelgomes.xyz
     setup_app_templates:
       - app
 
@@ -52,7 +52,7 @@ apps:
     <<: *common
 
     match_if_app_name_starts_with: true
-    default_domain: cpl.rafaelgomes.xyz
+    default_domain: cpflow.rafaelgomes.xyz
     setup_app_templates:
       - app
       - rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ SimpleCov.start do
   end
 end
 
-require_relative "../lib/cpl"
+require_relative "../lib/cpflow"
 require_relative "support/dummy_app_setup"
 require_relative "support/command_helpers"
 require_relative "support/date_time_helpers"
@@ -144,8 +144,8 @@ RSpec.configure do |config|
   end
 
   config.before do
-    allow(Cpl::Cli).to receive(:check_cpln_version)
-    allow(Cpl::Cli).to receive(:check_cpl_version)
+    allow(Cpflow::Cli).to receive(:check_cpln_version)
+    allow(Cpflow::Cli).to receive(:check_cpflow_version)
   end
 
   config.around do |example|

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -138,25 +138,25 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
   def create_app_if_not_exists(app, deploy: false, image_before_deploy_count: 0, image_after_deploy_count: 0) # rubocop:disable Metrics/MethodLength
     apps_to_delete.push(app) unless apps_to_delete.include?(app)
 
-    result = run_cpl_command("exists", "-a", app)
+    result = run_cpflow_command("exists", "-a", app)
     return app if result[:status].zero?
 
     puts "\nCreating app '#{app}' for tests\n\n" if ENV.fetch("VERBOSE_TESTS", nil) == "true"
 
-    run_cpl_command!("setup-app", "-a", app, "--skip-secrets-setup")
+    run_cpflow_command!("setup-app", "-a", app, "--skip-secrets-setup")
 
     image_before_deploy_count.times do
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
-    run_cpl_command!("deploy-image", "-a", app) if deploy
+    run_cpflow_command!("deploy-image", "-a", app) if deploy
     image_after_deploy_count.times do
-      run_cpl_command!("build-image", "-a", app)
+      run_cpflow_command!("build-image", "-a", app)
     end
 
     app
   end
 
-  def run_cpl_command(*args, raise_errors: false) # rubocop:disable Metrics/MethodLength
+  def run_cpflow_command(*args, raise_errors: false) # rubocop:disable Metrics/MethodLength
     LogHelpers.write_command_to_log(args.join(" "))
 
     result = {
@@ -169,7 +169,7 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     original_stdout = replace_stdout
 
     begin
-      Cpl::Cli.start(args)
+      Cpflow::Cli.start(args)
     rescue SystemExit => e
       result[:status] = e.status
     end
@@ -184,15 +184,15 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     result
   end
 
-  def run_cpl_command!(*args)
-    run_cpl_command(*args, raise_errors: true)
+  def run_cpflow_command!(*args)
+    run_cpflow_command(*args, raise_errors: true)
   end
 
-  def spawn_cpl_command(*args, stty_rows: nil, stty_cols: nil, wait_for_process: true)
+  def spawn_cpflow_command(*args, stty_rows: nil, stty_cols: nil, wait_for_process: true)
     cmd = ""
     cmd += "stty rows #{stty_rows} && " if stty_rows
     cmd += "stty cols #{stty_cols} && " if stty_cols
-    cmd += "#{cpl_executable_with_simplecov} #{args.join(' ')}"
+    cmd += "#{cpflow_executable_with_simplecov} #{args.join(' ')}"
 
     LogHelpers.write_command_to_log(cmd)
 
@@ -235,12 +235,12 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     contents
   end
 
-  def cpl_executable
-    File.join(root_directory, "cpl")
+  def cpflow_executable
+    File.join(root_directory, "cpflow")
   end
 
-  def cpl_executable_with_simplecov
-    "ruby -r #{simplecov_spawn_file} #{cpl_executable}"
+  def cpflow_executable_with_simplecov
+    "ruby -r #{simplecov_spawn_file} #{cpflow_executable}"
   end
 
   def simplecov_spawn_file

--- a/spec/support/dummy_app_setup.rb
+++ b/spec/support/dummy_app_setup.rb
@@ -14,7 +14,7 @@ module DummyAppSetup
       puts "\n\nNo dummy apps to delete\n"
     else
       CommandHelpers.apps_to_delete.each do |app|
-        CommandHelpers.run_cpl_command("delete", "-a", app, "--yes")
+        CommandHelpers.run_cpflow_command("delete", "-a", app, "--yes")
       end
     end
 


### PR DESCRIPTION
Fixes #191 

Renames the CLI from `cpl` to `cpflow`. Since we'll need to update the old gem with a deprecation warning and create a new gem, see #203 for the deprecation complement.

The vast majority of the changes were automatically generated.

First, by searching and replacing for the following regexes in the code:

```
cpl(?!n) -> cpflow
CPL(?!N) -> CPFLOW
Cpl(?!n) -> Cpflow
```

Then, by running the scripts below to rename the files:

```
find . -depth -regex '.*cpl$' -not -path '*/.git/*' -exec rename 's/cpl$/cpflow/' {} \;
find . -depth -regex '.*cpl[^n].*' -not -path '*/.git/*' -exec rename 's/cpl(?!n)/cpflow/' {} \;
```

The only manual changes were in the commit f55340870f766c62aac9cdecd547a8345e132de5.