### PR TITLE
Deprecate `cpl`

### DIFF
--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["rubygems_mfa_required"] = "true"
 
-  spec.post_install_message = "DEPRECATED: The `cpl` gem has been renamed to `shakaflow` " \
+  spec.post_install_message = "DEPRECATED: The `cpl` gem has been renamed to `cpflow` " \
                               "and will no longer be supported. " \
                               "Please switch to `shakaflow` as soon as possible."
 end

--- a/cpl.gemspec
+++ b/cpl.gemspec
@@ -38,4 +38,8 @@ Gem::Specification.new do |spec|
   spec.executables = ["cpl"]
 
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.post_install_message = "DEPRECATED: The `cpl` gem has been renamed to `shakaflow` " \
+                              "and will no longer be supported. " \
+                              "Please switch to `shakaflow` as soon as possible."
 end

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -73,9 +73,9 @@ module Cpl
 
       @warned_deprecated_gem = true
 
-      ::Shell.warn_deprecated("This gem has been renamed to `shakaflow` " \
+      ::Shell.warn_deprecated("This gem has been renamed to `cpflow` " \
                               "and will no longer be supported. " \
-                              "Please switch to `shakaflow` as soon as possible.")
+                              "Please switch to `cpflow` as soon as possible.")
     end
 
     def self.check_cpln_version # rubocop:disable Metrics/MethodLength

--- a/lib/cpl.rb
+++ b/lib/cpl.rb
@@ -60,11 +60,22 @@ module Cpl
     def self.start(*args)
       ENV["CPLN_SKIP_UPDATE_CHECK"] = "true"
 
+      warn_deprecated_gem
       check_cpln_version
       check_cpl_version
       fix_help_option
 
       super(*args)
+    end
+
+    def self.warn_deprecated_gem
+      return if @warned_deprecated_gem
+
+      @warned_deprecated_gem = true
+
+      ::Shell.warn_deprecated("This gem has been renamed to `shakaflow` " \
+                              "and will no longer be supported. " \
+                              "Please switch to `shakaflow` as soon as possible.")
     end
 
     def self.check_cpln_version # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Complement of #202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deprecation warning message indicating that the `cpl` gem has been renamed to `shakaflow`.
  - Users are advised to transition to the `shakaflow` gem promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->