### PR TITLE
Fix issue where common options are not forwarded to other commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ CPLN_ORG=your-org-for-tests bundle exec rspec --tag slow
 2. Use the `--trace` option to see full logging of HTTP requests. Warning, this will display keys to your logs or console.
 1. Add a breakpoint (`debugger`) to any line of code you want to debug.
 2. Modify the `lib/command/test.rb` file to trigger the code you want to test. To simulate a command, you can use
-   `Cpflow::Cli.start` (e.g., `Cpflow::Cli.start(["deploy-image", "-a", "my-app-name"])` would be the same as running
+   `run_cpflow_command` (e.g., `run_cpflow_command("deploy-image", "-a", "my-app-name")` would be the same as running
    `cpflow deploy-image -a my-app-name`).
 3. Run the `test` command in your test app with a `.controlplane` directory.
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -527,7 +527,7 @@ module Command
       progress.puts("Running #{title}...\n\n")
 
       begin
-        Cpflow::Cli.start(["run", "-a", config.app, "--image", "latest", "--", command])
+        run_cpflow_command("run", "-a", config.app, "--image", "latest", "--", command)
       rescue SystemExit => e
         progress.puts
 
@@ -535,6 +535,20 @@ module Command
 
         progress.puts("Finished running #{title}.\n\n")
       end
+    end
+
+    def run_cpflow_command(command, *args)
+      common_args = []
+
+      self.class.common_options.each do |option|
+        value = config.options[option[:name]]
+        next if value.nil?
+
+        name = "--#{option[:name].to_s.tr('_', '-')}"
+        common_args.push(name, value)
+      end
+
+      Cpflow::Cli.start([command, *common_args, *args])
     end
   end
 end

--- a/lib/command/cleanup_stale_apps.rb
+++ b/lib/command/cleanup_stale_apps.rb
@@ -73,7 +73,7 @@ module Command
     end
 
     def delete_app(app)
-      Cpflow::Cli.start(["delete", "-a", app, "--yes"])
+      run_cpflow_command("delete", "-a", app, "--yes")
     end
   end
 end

--- a/lib/command/maintenance_off.rb
+++ b/lib/command/maintenance_off.rb
@@ -39,7 +39,7 @@ module Command
       cp.fetch_workload!(maintenance_workload)
 
       # Start all other workloads
-      Cpflow::Cli.start(["ps:start", "-a", config.app, "--wait"])
+      run_cpflow_command("ps:start", "-a", config.app, "--wait")
 
       progress.puts
 
@@ -54,7 +54,7 @@ module Command
       progress.puts
 
       # Stop maintenance workload
-      Cpflow::Cli.start(["ps:stop", "-a", config.app, "-w", maintenance_workload, "--wait"])
+      run_cpflow_command("ps:stop", "-a", config.app, "-w", maintenance_workload, "--wait")
 
       progress.puts("\nMaintenance mode disabled for app '#{config.app}'.")
     end

--- a/lib/command/maintenance_on.rb
+++ b/lib/command/maintenance_on.rb
@@ -39,7 +39,7 @@ module Command
       cp.fetch_workload!(maintenance_workload)
 
       # Start maintenance workload
-      Cpflow::Cli.start(["ps:start", "-a", config.app, "-w", maintenance_workload, "--wait"])
+      run_cpflow_command("ps:start", "-a", config.app, "-w", maintenance_workload, "--wait")
 
       progress.puts
 
@@ -54,7 +54,7 @@ module Command
       progress.puts
 
       # Stop all other workloads
-      Cpflow::Cli.start(["ps:stop", "-a", config.app, "--wait"])
+      run_cpflow_command("ps:stop", "-a", config.app, "--wait")
 
       progress.puts("\nMaintenance mode enabled for app '#{config.app}'.")
     end

--- a/lib/command/no_command.rb
+++ b/lib/command/no_command.rb
@@ -14,9 +14,9 @@ module Command
 
     def call
       if config.options[:version]
-        Cpflow::Cli.start(["version"])
+        run_cpflow_command("version")
       else
-        Cpflow::Cli.start(["help"])
+        run_cpflow_command("help")
       end
     end
   end

--- a/lib/command/promote_app_from_upstream.rb
+++ b/lib/command/promote_app_from_upstream.rb
@@ -25,14 +25,14 @@ module Command
     private
 
     def copy_image_from_upstream
-      Cpflow::Cli.start(["copy-image-from-upstream", "-a", config.app, "-t", config.options[:upstream_token]])
+      run_cpflow_command("copy-image-from-upstream", "-a", config.app, "-t", config.options[:upstream_token])
       progress.puts
     end
 
     def deploy_image
       args = []
       args.push("--run-release-phase") if config.current[:release_script]
-      Cpflow::Cli.start(["deploy-image", "-a", config.app, *args])
+      run_cpflow_command("deploy-image", "-a", config.app, *args)
     end
   end
 end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -306,7 +306,7 @@ module Command
           exit(ExitCode::SUCCESS)
         end
 
-        Cpflow::Cli.start(["logs", *app_workload_replica_args])
+        run_cpflow_command("logs", *app_workload_replica_args)
       end
       Process.detach(logs_pid)
 

--- a/lib/command/setup_app.rb
+++ b/lib/command/setup_app.rb
@@ -42,7 +42,7 @@ module Command
 
       args = []
       args.push("--add-app-identity") unless skip_secrets_setup
-      Cpflow::Cli.start(["apply-template", *templates, "-a", config.app, *args])
+      run_cpflow_command("apply-template", *templates, "-a", config.app, *args)
 
       bind_identity_to_policy unless skip_secrets_setup
       run_post_creation_hook unless config.options[:skip_post_creation_hook]

--- a/lib/command/test.rb
+++ b/lib/command/test.rb
@@ -16,8 +16,8 @@ module Command
     def call
       # Modify this method to trigger the code you want to test.
       # You can use `debugger` to debug.
-      # You can use `Cpflow::Cli.start` to simulate a command
-      # (e.g., `Cpflow::Cli.start(["deploy-image", "-a", "my-app-name"])`).
+      # You can use `run_cpflow_command` to simulate a command
+      # (e.g., `run_cpflow_command("deploy-image", "-a", "my-app-name")`).
     end
   end
 end

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -157,4 +157,24 @@ describe Command::SetupApp do
       expect(result[:stderr]).not_to include("Running post-creation hook")
     end
   end
+
+  context "when forwarding org" do
+    let!(:app) { dummy_test_app("undefined-org") }
+
+    before do
+      allow(ENV).to receive(:fetch).and_call_original
+      allow(ENV).to receive(:fetch).with("CPLN_ORG", nil).and_return(nil)
+    end
+
+    after do
+      run_cpflow_command!("delete", "-a", app, "--org", dummy_test_org, "--yes")
+    end
+
+    it "forwards org correctly to apply-template" do
+      result = run_cpflow_command("setup-app", "-a", app, "--org", dummy_test_org, "--skip-secrets-setup")
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("[app] #{app}")
+    end
+  end
 end

--- a/spec/dummy/.controlplane/controlplane.yml
+++ b/spec/dummy/.controlplane/controlplane.yml
@@ -109,6 +109,8 @@ apps:
 
     match_if_app_name_starts_with: true
     cpln_org:
+    setup_app_templates:
+      - app
 
   dummy-test-rails-non-app-image-{GLOBAL_IDENTIFIER}:
     <<: *common


### PR DESCRIPTION
Fixes #206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified command execution by replacing direct calls to `Cpflow::Cli.start` with a new `run_cpflow_command` method across multiple command files. This improves modularity and reusability.

- **Tests**
  - Added a new context block in `setup_app_spec.rb` to forward the organization correctly to the `apply-template` command and verify expected behavior.

- **Chores**
  - Updated `controlplane.yml` for the `dummy` application to include the `setup_app_templates` key, enabling setup app templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->