### PR TITLE
Separate docker build & docker push steps

### DIFF
--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -36,8 +36,7 @@ module Command
 
       cp.image_build(image_url, dockerfile: dockerfile,
                                 docker_args: config.args,
-                                build_args: build_args,
-                                push: false)
+                                build_args: build_args)
 
       push_path = "/org/#{config.org}/image/#{image_name}"
 

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -36,9 +36,14 @@ module Command
 
       cp.image_build(image_url, dockerfile: dockerfile,
                                 docker_args: config.args,
-                                build_args: build_args)
+                                build_args: build_args,
+                                push: false)
 
-      progress.puts("\nPushed image to '/org/#{config.org}/image/#{image_name}'.\n\n")
+      push_path = "/org/#{config.org}/image/#{image_name}"
+
+      progress.puts("\nPushing image to '#{push_path}'...\n\n")
+      cp.image_push(image_url)
+      progress.puts("\nPushed image to '#{push_path}'.\n\n")
 
       step("Waiting for image to be available", retry_on_failure: true) do
         images = cp.query_images["items"]

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -90,7 +90,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.query_images(org: a_org, gvc: a_gvc, gvc_op_type: gvc_op)
   end
 
-  def image_build(image, dockerfile:, docker_args: [], build_args: [], push: true)
+  def image_build(image, dockerfile:, docker_args: [], build_args: [])
     # https://docs.controlplane.com/guides/push-image#step-2
     # Might need to use `docker buildx build` if compatiblitity issues arise
     cmd = "docker build --platform=linux/amd64 -t #{image} -f #{dockerfile}"
@@ -99,9 +99,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     cmd += " #{docker_args.join(' ')}" if docker_args.any?
     build_args.each { |build_arg| cmd += " --build-arg #{build_arg}" }
     cmd += " #{config.app_dir}"
-    perform!(cmd)
 
-    image_push(image) if push
+    perform!(cmd)
   end
 
   def fetch_image_details(image)


### PR DESCRIPTION
### What does this PR?

This PR separates `docker build` and `docker push` steps

### Why?

1. Don't run `cpln image docker-login --org <org_name>` so that push to private registry (`<org_name>.registry.cpln.io`) won't succeed
2. Run `cpflow build-image -a <app_name>`

This will output something like this:
```
Building image from Dockerfile '<path_to_dockerfile>'...
ERROR: Command exited with non-zero status.
```

This message is misleading because `docker build` succeeds but `docker push` fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced image build process to automatically push images to a specified path with progress updates.
- **Improvements**
  - Simplified the image build method to focus solely on the Docker image construction, removing unnecessary push functionality for clearer operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->