### PR TITLE
Add rspec-specific GitHub workflow

### DIFF
--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -10,7 +10,10 @@ on:
         required: true
         type: string
       test-tag:
-        required: true
+        required: false
+        type: string
+      spec_paths:
+        required: false
         type: string
 
 jobs:
@@ -41,7 +44,7 @@ jobs:
           cpln profile create default --token $CPLN_TOKEN_CI --org $CPLN_ORG
           cpln image docker-login
       - name: Run tests
-        run: bundle exec rspec --format documentation --tag ${{ inputs.test-tag }}
+        run: bundle exec rspec --format documentation ${{ inputs.test-tag && format('--tag {0}', inputs.test-tag) }} ${{ inputs.spec_paths }}
       - name: Upload spec log
         uses: actions/upload-artifact@master
         if: always()

--- a/.github/workflows/rspec-shared.yml
+++ b/.github/workflows/rspec-shared.yml
@@ -3,13 +3,13 @@ name: RSpec Shared
 on:
   workflow_call:
     inputs:
-      os-version:
+      os_version:
         required: true
         type: string
-      ruby-version:
+      ruby_version:
         required: true
         type: string
-      test-tag:
+      test_tag:
         required: false
         type: string
       spec_paths:
@@ -18,7 +18,7 @@ on:
 
 jobs:
   rspec:
-    runs-on: ${{ inputs.os-version }}
+    runs-on: ${{ inputs.os_version }}
     env:
       RAILS_ENV: test
       # We have to add "_CI" to the end, otherwise it messes with tests where we switch profiles,
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ inputs.ruby-version }}
+          ruby-version: ${{ inputs.ruby_version }}
           bundler-cache: true
       - name: Install dependencies
         run: bundle install
@@ -44,16 +44,16 @@ jobs:
           cpln profile create default --token $CPLN_TOKEN_CI --org $CPLN_ORG
           cpln image docker-login
       - name: Run tests
-        run: bundle exec rspec --format documentation ${{ inputs.test-tag && format('--tag {0}', inputs.test-tag) }} ${{ inputs.spec_paths }}
+        run: bundle exec rspec --format documentation ${{ inputs.test_tag && format('--tag {0}', inputs.test_tag) }} ${{ inputs.spec_paths }}
       - name: Upload spec log
         uses: actions/upload-artifact@master
         if: always()
         with:
-          name: spec-${{ inputs.test-tag }}-${{ github.run_id }}-${{ inputs.os-version }}-${{ inputs.ruby-version }}.log
+          name: spec-${{ inputs.test_tag }}-${{ github.run_id }}-${{ inputs.os_version }}-${{ inputs.ruby_version }}.log
           path: spec.log
       - name: Upload coverage results
         uses: actions/upload-artifact@master
         if: always()
         with:
-          name: coverage-report-${{ inputs.test-tag }}-${{ github.run_id }}-${{ inputs.os-version }}-${{ inputs.ruby-version }}
+          name: coverage-report-${{ inputs.test_tag }}-${{ github.run_id }}-${{ inputs.os_version }}-${{ inputs.ruby_version }}
           path: coverage

--- a/.github/workflows/rspec-specific.yml
+++ b/.github/workflows/rspec-specific.yml
@@ -1,0 +1,18 @@
+name: RSpec Specific
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec_paths:
+        description: "Test files or directories that should be run"
+        required: true
+
+jobs:
+  rspec-specific-tests:
+    name: RSpec (Specific)
+    uses: ./.github/workflows/rspec-shared.yml
+    with:
+      os-version: ubuntu-latest
+      ruby-version: "3.2"
+      spec_paths: ${{ inputs.spec_paths }}
+    secrets: inherit

--- a/.github/workflows/rspec-specific.yml
+++ b/.github/workflows/rspec-specific.yml
@@ -8,11 +8,11 @@ on:
         required: true
 
 jobs:
-  rspec-specific-tests:
+  rspec-specific:
     name: RSpec (Specific)
     uses: ./.github/workflows/rspec-shared.yml
     with:
-      os-version: ubuntu-latest
-      ruby-version: "3.2"
+      os_version: ubuntu-latest
+      ruby_version: "3.2"
       spec_paths: ${{ inputs.spec_paths }}
     secrets: inherit

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -12,9 +12,9 @@ jobs:
     name: RSpec (Fast)
     uses: ./.github/workflows/rspec-shared.yml
     with:
-      os-version: ubuntu-latest
-      ruby-version: "3.2"
-      test-tag: ~slow
+      os_version: ubuntu-latest
+      ruby_version: "3.2"
+      test_tag: ~slow
     secrets: inherit
 
   rspec-slow:
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/rspec-shared.yml
     if: github.event_name == 'workflow_dispatch'
     with:
-      os-version: ubuntu-latest
-      ruby-version: "3.2"
-      test-tag: slow
+      os_version: ubuntu-latest
+      ruby_version: "3.2"
+      test_tag: slow
     secrets: inherit


### PR DESCRIPTION
### What does this PR do and why?

This PR adds new `rspec-spicific` GitHub workflow so that job can be triggered manually to run specific tests

### Does it work?

Example of manually triggered job with passing `spec/command/config_spec.rb` as `spec_paths` argument - https://github.com/zzaakiirr/control-plane-flow/actions/runs/10020011552/job/27697199967

<img width="1017" alt="Screenshot 2024-07-20 at 15 07 02" src="https://github.com/user-attachments/assets/06ec2381-ee53-4c0a-90be-fecbdc3b5416">

Note, that "Setup Control Plane tools" step is intentionally skipped and tests fail because of that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new workflow for running specific RSpec tests, allowing users to manually specify test files or directories.
	- Enhanced configurability of the shared workflow by making `test_tag` optional and adding `spec_paths` for more targeted test executions.

- **Improvements**
	- Increased flexibility in test execution by allowing conditions on the inclusion of tags and specifying paths for RSpec tests.
	- Standardized naming conventions for workflow parameters, improving consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->