### PR TITLE
Remove config validation for cpflow generate command

### DIFF
--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -26,6 +26,7 @@ module Command
       ```
     EX
     WITH_INFO_HEADER = false
+    VALIDATIONS = [].freeze
 
     def call
       if controlplane_directory_exists?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,4 +152,16 @@ RSpec.configure do |config|
     # Times out after 10 minutes
     Timeout.timeout(600) { example.run }
   end
+
+  config.around(:example, :without_config_file) do |example|
+    CommandHelpers.unset_config_file
+    example.run
+    CommandHelpers.configure_config_file
+  end
+
+  config.around(:example, :enable_validations) do |example|
+    ENV["DISABLE_VALIDATIONS"] = "false"
+    example.run
+    ENV["DISABLE_VALIDATIONS"] = "true"
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -154,7 +154,7 @@ RSpec.configure do |config|
   end
 
   config.around(:example, :without_config_file) do |example|
-    CommandHelpers.unset_config_file
+    CommandHelpers.delete_config_file
     example.run
     CommandHelpers.configure_config_file
   end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -63,11 +63,16 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     ENV["CONFIG_FILE_PATH"] = @@tmp_config_file.path
   end
 
+  def unset_config_file
+    @@tmp_config_file = nil # rubocop:disable Style/ClassVars
+    ENV["CONFIG_FILE_PATH"] = nil
+  end
+
   def delete_config_file
     return unless @@tmp_config_file
 
     File.delete(@@tmp_config_file.path)
-    @@tmp_config_file = nil # rubocop:disable Style/ClassVars
+    unset_config_file
   end
 
   def temporarily_switch_config_file(extra_prefix = "")

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -63,16 +63,13 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     ENV["CONFIG_FILE_PATH"] = @@tmp_config_file.path
   end
 
-  def unset_config_file
-    @@tmp_config_file = nil # rubocop:disable Style/ClassVars
-    ENV["CONFIG_FILE_PATH"] = nil
-  end
-
   def delete_config_file
     return unless @@tmp_config_file
 
     File.delete(@@tmp_config_file.path)
-    unset_config_file
+
+    @@tmp_config_file = nil # rubocop:disable Style/ClassVars
+    ENV["CONFIG_FILE_PATH"] = nil
   end
 
   def temporarily_switch_config_file(extra_prefix = "")


### PR DESCRIPTION
### What does this PR do?

This PR:
- removes `config` validation from `cpflow generate` command 
- fixes specs for this command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a dedicated constant for validations in the `Generate` class, allowing for future enhancement of validation rules.

- **Bug Fixes**
	- Improved test robustness by adding metadata tags for validation scenarios and streamlined configuration file checks in tests.

- **Documentation**
	- Enhanced clarity in test setups by defining configuration file paths and ensuring isolated testing conditions.

- **Refactor**
	- Consolidated configuration file handling into a new method for improved readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->