### PR TITLE
Add terraform generate command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -444,6 +444,14 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 cpflow setup-app -a $APP_NAME
 ```
 
+### `generate`
+
+Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+
+```sh
+cpflow generate
+```
+
 ### `version`
 
 - Displays the current version of the CLI

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -38,16 +38,27 @@ module Command
     WITH_INFO_HEADER = true
     # Which validations to run before the command
     VALIDATIONS = %w[config].freeze
+    SUBCOMMAND = nil
 
     def initialize(config)
       @config = config
     end
 
-    def self.all_commands
-      Dir["#{__dir__}/*.rb"].each_with_object({}) do |file, result|
+    def self.all_commands # rubocop:disable Metrics/MethodLength
+      Dir["#{__dir__}/**/*.rb"].each_with_object({}) do |file, result|
         filename = File.basename(file, ".rb")
-        classname = File.read(file).match(/^\s+class (\w+) < Base($| .*$)/)&.captures&.first
-        result[filename.to_sym] = Object.const_get("::Command::#{classname}") if classname
+
+        classname = File.read(file).match(/^\s+class (\w+) < (?:.*Base)(?:$| .*$)/)&.captures&.first
+        next unless classname
+
+        namespaces = File.read(file).scan(/^\s+module (\w+)/).flatten
+        full_classname = [*namespaces, classname].join("::").prepend("::")
+
+        command_key = filename
+        prefix = namespaces[1..1].map(&:downcase).join("_")
+        command_key.prepend(prefix.concat("_")) unless prefix.empty?
+
+        result[command_key.to_sym] = Object.const_get(full_classname)
       end
     end
 

--- a/lib/command/base_sub_command.rb
+++ b/lib/command/base_sub_command.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Inspired by https://github.com/rails/thor/wiki/Subcommands
+class BaseSubCommand < Thor
+  def self.banner(command, _namespace = nil, _subcommand = false) # rubocop:disable Style/OptionalBooleanParameter
+    "#{basename} #{subcommand_prefix} #{command.usage}"
+  end
+
+  def self.subcommand_prefix
+    name
+      .gsub(/.*::/, "")
+      .gsub(/^[A-Z]/) { |match| match[0].downcase }
+      .gsub(/[A-Z]/) { |match| "-#{match[0].downcase}" }
+  end
+end

--- a/lib/command/generate.rb
+++ b/lib/command/generate.rb
@@ -9,7 +9,7 @@ module Command
     end
 
     def self.source_root
-      File.expand_path("../", __dir__)
+      Cpflow.root_path
     end
   end
 
@@ -26,6 +26,7 @@ module Command
       ```
     EX
     WITH_INFO_HEADER = false
+    VALIDATIONS = [].freeze
 
     def call
       if controlplane_directory_exists?

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Command
+  module Terraform
+    class Generate < ::Command::Base
+      SUBCOMMAND = "terraform"
+      NAME = "generate"
+      DESCRIPTION = "Generates terraform configuration files"
+      LONG_DESCRIPTION = <<~DESC
+        Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+      DESC
+      EXAMPLES = <<~EX
+        ```sh
+        cpflow generate
+        ```
+      EX
+      WITH_INFO_HEADER = false
+      VALIDATIONS = [].freeze
+
+      def call
+        File.write(terraform_dir.join("providers.tf"), cpln_provider.to_tf)
+      end
+
+      private
+
+      def cpln_provider
+        ::Terraform::Config::RequiredProvider.new("cpln", source: "controlplane-com/cpln", version: "~> 1.0")
+      end
+
+      def terraform_dir
+        @terraform_dir ||= Pathname.new("#{Cpflow.root_path}/terraform").tap do |path|
+          FileUtils.mkdir_p(path)
+        end
+      end
+    end
+  end
+end

--- a/lib/core/terraform/config/base.rb
+++ b/lib/core/terraform/config/base.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# TODO: Fix indentations
+module Terraform
+  module Config
+    class Base
+      def to_tf
+        raise NotImplementedError
+      end
+
+      private
+
+      def block(name, *labels)
+        switch_context do
+          context.put "#{name} #{labels.map { |label| tf_value(label) }.join(' ')} {\n"
+          yield
+          context.put "}\n"
+        end
+
+        context.output
+      end
+
+      def argument(name, value, optional: false)
+        return if value.nil? && optional
+
+        content =
+          if value.is_a?(Hash)
+            "{\n#{value.map { |n, v| "#{n} = #{tf_value(v)}\n".indent(context.indent) }.join("\n")}\n}\n"
+          else
+            "#{tf_value(value)}\n"
+          end
+
+        context.put "#{name} = #{content}".indent(context.indent)
+      end
+
+      def switch_context
+        old_context = context
+        @context = Context.new(indent: old_context.indent + 2)
+        yield
+      ensure
+        old_context.put(context.output)
+        @context = old_context
+      end
+
+      def context
+        @context ||= Context.new(indent: 0)
+      end
+
+      def tf_value(value)
+        value = value.to_s if value.is_a?(Symbol)
+
+        case value
+        when String
+          expression?(value) ? value : "\"#{value}\""
+        else
+          value
+        end
+      end
+
+      def expression?(value)
+        value.start_with?("var.") || value.start_with?("locals.")
+      end
+
+      class Context
+        attr_accessor :output, :indent
+
+        def initialize(indent: 0)
+          @output = ""
+          @indent = indent
+        end
+
+        def put(content)
+          @output += content.indent(indent)
+        end
+      end
+    end
+  end
+end

--- a/lib/core/terraform/config/required_provider.rb
+++ b/lib/core/terraform/config/required_provider.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Terraform
+  module Config
+    class RequiredProvider < Base
+      attr_reader :name, :options
+
+      def initialize(name, **options)
+        super()
+
+        @name = name
+        @options = options
+      end
+
+      def to_tf
+        block :terraform do
+          block :required_providers do
+            argument name, options
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -17,6 +17,8 @@ require_relative "constants/exit_code"
 
 # We need to require base before all commands, since the commands inherit from it
 require_relative "command/base"
+# We need to require base config before all commands, since the terraform configs inherit from it
+require_relative "core/terraform/config/base"
 
 modules = Dir["#{__dir__}/**/*.rb"].reject do |file|
   file == __FILE__ || file.end_with?("base.rb")
@@ -51,8 +53,27 @@ class Thor
   end
 end
 
+# String methods copied from Rails
+# rubocop:disable Style/OptionalBooleanParameter, Lint/UnderscorePrefixedVariableName
+class String
+  def indent(amount, indent_string = nil, indent_empty_lines = false)
+    dup.tap { |_| _.indent!(amount, indent_string, indent_empty_lines) }
+  end
+
+  def indent!(amount, indent_string = nil, indent_empty_lines = false)
+    indent_string = indent_string || self[/^[ \t]/] || " "
+    re = indent_empty_lines ? /^/ : /^(?!$)/
+    gsub!(re, indent_string * amount)
+  end
+end
+# rubocop:enable Style/OptionalBooleanParameter, Lint/UnderscorePrefixedVariableName
+
 module Cpflow
   class Error < StandardError; end
+
+  def self.root_path
+    File.expand_path("../", __dir__)
+  end
 
   class Cli < Thor # rubocop:disable Metrics/ClassLength
     package_name "cpflow"
@@ -111,6 +132,8 @@ module Cpflow
     # (it basically changes it to `cpflow --help COMMAND`, which Thor recognizes)
     # Based on https://stackoverflow.com/questions/49042591/how-to-add-help-h-flag-to-thor-command
     def self.fix_help_option
+      return unless (ARGV & all_subcommands).empty?
+
       help_mappings = Thor::HELP_MAPPINGS + ["help"]
       matches = help_mappings & ARGV
       matches.each do |match|
@@ -149,6 +172,10 @@ module Cpflow
       ::Command::Base.all_commands.merge(deprecated_commands)
     end
 
+    def self.all_subcommands
+      ::Command::Base.all_commands.values.map { |command| command::SUBCOMMAND }.compact
+    end
+
     def self.process_option_params(params)
       # Ensures that if no value is provided for a non-boolean option (e.g., `cpflow command --option`),
       # it defaults to an empty string instead of the option name (which is the default Thor behavior)
@@ -181,6 +208,7 @@ module Cpflow
       hide = command_class::HIDE || deprecated
       with_info_header = command_class::WITH_INFO_HEADER
       validations = command_class::VALIDATIONS
+      subcommand = command_class::SUBCOMMAND
 
       long_description += "\n#{examples}" if examples.length.positive?
 
@@ -188,21 +216,39 @@ module Cpflow
       # so we store it here to be able to use it
       raise_args_error = ->(*args) { handle_argument_error(commands[name_for_method], ArgumentError, *args) }
 
-      desc(usage, description, hide: hide)
-      long_desc(long_description)
-
-      command_options.each do |option|
-        params = process_option_params(option[:params])
-        method_option(option[:name], **params)
-      end
-
       # We'll handle required options manually in `Config`
       required_options = command_options.select { |option| option[:params][:required] }.map { |option| option[:name] }
       @commands_with_required_options.push(name_for_method.to_sym) if required_options.any?
 
       @commands_with_extra_options.push(name_for_method.to_sym) if accepts_extra_options
 
-      define_method(name_for_method) do |*provided_args| # rubocop:disable Metrics/BlockLength, Metrics/MethodLength
+      klass =
+        if subcommand
+          klass_name = subcommand.to_s.split("_").collect(&:capitalize).join
+
+          if Object.const_defined?("Cpflow::#{klass_name}")
+            Cpflow.const_get(klass_name)
+          else
+            Cpflow.const_set(klass_name, Class.new(BaseSubCommand)).tap do |subcommand_klass|
+              desc subcommand, "#{subcommand.capitalize} commands"
+              subcommand subcommand, subcommand_klass
+            end
+          end
+        else
+          self
+        end
+
+      klass.class_eval do
+        desc(usage, description, hide: hide)
+        long_desc(long_description)
+
+        command_options.each do |option|
+          params = process_option_params(option[:params])
+          method_option(option[:name], **params)
+        end
+      end
+
+      klass.define_method(name_for_method) do |*provided_args| # rubocop:disable Metrics/BlockLength, Metrics/MethodLength
         if deprecated
           normalized_old_name = ::Helpers.normalize_command_name(command_key)
           ::Shell.warn_deprecated("Command '#{normalized_old_name}' is deprecated, " \


### PR DESCRIPTION
### What does this PR do?

This PR introduces new subcommand `terraform` for `cpflow` CLI tool. Currently this subcommand has only 1 command - `generate`

### Important note

This is Draft PR, the main purpose of which is to get opinions on Terraform DSL feature implementation