### PR TITLE
Introduce terraform subcommand

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -444,9 +444,9 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 cpflow setup-app -a $APP_NAME
 ```
 
-### `generate`
+### `terraform generate`
 
-Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+- Generates terraform configuration files based on `controlplane.yml` and `templates/` config
 
 ```sh
 cpflow terraform generate

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -444,6 +444,14 @@ cpflow run -a $APP_NAME --entrypoint /app/alternative-entrypoint.sh -- rails db:
 cpflow setup-app -a $APP_NAME
 ```
 
+### `generate`
+
+Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+
+```sh
+cpflow terraform generate
+```
+
 ### `version`
 
 - Displays the current version of the CLI

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -12,6 +12,8 @@ module Command
     VALIDATIONS_WITH_ADDITIONAL_OPTIONS = %w[templates].freeze
     ALL_VALIDATIONS = VALIDATIONS_WITHOUT_ADDITIONAL_OPTIONS + VALIDATIONS_WITH_ADDITIONAL_OPTIONS
 
+    # Used to call the command (`cpflow SUBCOMMAND_NAME NAME`)
+    SUBCOMMAND_NAME = nil
     # Used to call the command (`cpflow NAME`)
     # NAME = ""
     # Displayed when running `cpflow help` or `cpflow help NAME` (defaults to `NAME`)
@@ -38,7 +40,6 @@ module Command
     WITH_INFO_HEADER = true
     # Which validations to run before the command
     VALIDATIONS = %w[config].freeze
-    SUBCOMMAND = nil
 
     def initialize(config)
       @config = config
@@ -55,7 +56,7 @@ module Command
         full_classname = [*namespaces, classname].join("::").prepend("::")
 
         command_key = File.basename(file, ".rb")
-        prefix = namespaces[1..1].map(&:downcase).join("_")
+        prefix = namespaces[1..].map(&:downcase).join("_")
         command_key.prepend(prefix.concat("_")) unless prefix.empty?
 
         result[command_key.to_sym] = Object.const_get(full_classname)

--- a/lib/command/base_sub_command.rb
+++ b/lib/command/base_sub_command.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Inspired by https://github.com/rails/thor/wiki/Subcommands
+class BaseSubCommand < Thor
+  def self.banner(command, _namespace = nil, _subcommand = false) # rubocop:disable Style/OptionalBooleanParameter
+    "#{basename} #{subcommand_prefix} #{command.usage}"
+  end
+
+  def self.subcommand_prefix
+    name
+      .gsub(/.*::/, "")
+      .gsub(/^[A-Z]/) { |match| match[0].downcase }
+      .gsub(/[A-Z]/) { |match| "-#{match[0].downcase}" }
+  end
+end

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -2,18 +2,13 @@
 
 module Command
   module Terraform
-    class Generate < ::Command::Base
-      SUBCOMMAND = "terraform"
+    class Generate < Base
+      SUBCOMMAND_NAME = "terraform"
       NAME = "generate"
       DESCRIPTION = "Generates terraform configuration files"
       LONG_DESCRIPTION = <<~DESC
-        Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+        - Generates terraform configuration files based on `controlplane.yml` and `templates/` config
       DESC
-      EXAMPLES = <<~EX
-        ```sh
-        cpflow terraform generate
-        ```
-      EX
       WITH_INFO_HEADER = false
       VALIDATIONS = [].freeze
 

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Command
+  module Terraform
+    class Generate < ::Command::Base
+      SUBCOMMAND = "terraform"
+      NAME = "generate"
+      DESCRIPTION = "Generates terraform configuration files"
+      LONG_DESCRIPTION = <<~DESC
+        Generates terraform configuration files based on `controlplane.yml` and `templates/` config
+      DESC
+      EXAMPLES = <<~EX
+        ```sh
+        cpflow terraform generate
+        ```
+      EX
+      WITH_INFO_HEADER = false
+      VALIDATIONS = [].freeze
+
+      def call
+        # TODO: Implement
+      end
+    end
+  end
+end

--- a/script/update_command_docs
+++ b/script/update_command_docs
@@ -12,12 +12,16 @@ commands.keys.sort.each do |command_key|
   next if command_class::HIDE
 
   name = command_class::NAME
-  usage = command_class::USAGE.empty? ? name : command_class::USAGE
+  subcommand_name = command_class::SUBCOMMAND_NAME
+
+  full_command = [subcommand_name, name].compact.join(" ")
+
+  usage = command_class::USAGE.empty? ? full_command : command_class::USAGE
   options = command_class::OPTIONS
   long_description = command_class::LONG_DESCRIPTION
   examples = command_class::EXAMPLES
 
-  command_str = "### `#{name}`\n\n"
+  command_str = "### `#{full_command}`\n\n"
   command_str += "#{long_description.strip}\n\n"
 
   if examples.empty?

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -21,17 +21,20 @@ describe Cpflow do
   end
 
   it "handles subcommands correctly" do
-    result = run_cpflow_command("help")
+    result = run_cpflow_command("--help")
 
     expect(result[:status]).to eq(0)
 
-    Cpflow::Cli.subcommand_names.each do |subcommand|
-      expect(result[:stdout]).to include("#{package_name} #{subcommand}")
+    # Temporary solution, will be fixed with https://github.com/rails/thor/issues/742
+    basename = Cpflow::Cli.send(:basename)
 
-      subcommand_result = run_cpflow_command(subcommand, "help")
+    Cpflow::Cli.subcommand_names.each do |subcommand|
+      expect(result[:stdout]).to include("#{basename} #{subcommand}")
+
+      subcommand_result = run_cpflow_command(subcommand, "--help")
 
       expect(subcommand_result[:status]).to eq(0)
-      expect(subcommand_result[:stdout]).to include("#{package_name} #{subcommand} help [COMMAND]")
+      expect(subcommand_result[:stdout]).to include("#{basename} #{subcommand} help [COMMAND]")
     end
   end
 end

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -19,4 +19,19 @@ describe Cpflow do
       expect(result[:stderr]).to include("No value provided for option --#{option[:name].to_s.tr('_', '-')}")
     end
   end
+
+  it "handles subcommands correctly" do
+    result = run_cpflow_command("help")
+
+    expect(result[:status]).to eq(0)
+
+    Cpflow::Cli.subcommand_names.each do |subcommand|
+      expect(result[:stdout]).to include("#{package_name} #{subcommand}")
+
+      subcommand_result = run_cpflow_command(subcommand, "help")
+
+      expect(subcommand_result[:status]).to eq(0)
+      expect(subcommand_result[:stdout]).to include("#{package_name} #{subcommand} help [COMMAND]")
+    end
+  end
 end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -157,6 +157,9 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
   end
 
   def run_cpflow_command(*args, raise_errors: false) # rubocop:disable Metrics/MethodLength
+    program_name_before = $PROGRAM_NAME
+    $PROGRAM_NAME = package_name
+
     LogHelpers.write_command_to_log(args.join(" "))
 
     result = {
@@ -182,6 +185,8 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     raise result.to_json if result[:status].nonzero? && raise_errors
 
     result
+  ensure
+    $PROGRAM_NAME = program_name_before
   end
 
   def run_cpflow_command!(*args)
@@ -256,5 +261,9 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     current_directory = File.dirname(current_file_path)
 
     File.dirname(current_directory)
+  end
+
+  def package_name
+    @package_name ||= Cpflow::Cli.instance_variable_get("@package_name")
   end
 end

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -157,9 +157,6 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
   end
 
   def run_cpflow_command(*args, raise_errors: false) # rubocop:disable Metrics/MethodLength
-    program_name_before = $PROGRAM_NAME
-    $PROGRAM_NAME = package_name
-
     LogHelpers.write_command_to_log(args.join(" "))
 
     result = {
@@ -185,8 +182,6 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     raise result.to_json if result[:status].nonzero? && raise_errors
 
     result
-  ensure
-    $PROGRAM_NAME = program_name_before
   end
 
   def run_cpflow_command!(*args)
@@ -261,9 +256,5 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     current_directory = File.dirname(current_file_path)
 
     File.dirname(current_directory)
-  end
-
-  def package_name
-    @package_name ||= Cpflow::Cli.instance_variable_get("@package_name")
   end
 end


### PR DESCRIPTION
### What does this PR do?

This PR adds possibility to add subcommands to `cpflow` cli tool and adds `cpflow terraform generate` command which  does nothing (for now)

### Note

- Fixed `CommandHelpers#run_cpflow_command` so that `cpflow help` shows `cpflow <command_name>` i/o `rspec <command_name>`
- `Command::Terraform::Generate` will be implemented in feature PRs

### Screenshots

<img width="1552" alt="Screenshot 2024-07-30 at 13 29 22" src="https://github.com/user-attachments/assets/0e04b5eb-27fc-4f3c-806e-7870604808a3">
<img width="1440" alt="Screenshot 2024-07-30 at 13 30 06" src="https://github.com/user-attachments/assets/e83032c3-3bfb-4773-bd3b-81fa05ff5c48">
<img width="1440" alt="Screenshot 2024-07-30 at 13 30 38" src="https://github.com/user-attachments/assets/175f2f70-480a-416f-8142-5e196856d7e3">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `generate` command to automate Terraform configuration file creation in the CLI.
  
- **Bug Fixes**
  - Enhanced command discovery to include files in nested directories, improving the accessibility of commands.

- **Tests**
  - Added a new test case to verify proper handling of subcommands within the CLI.

- **Chores**
  - Improved command execution context management and introduced a utility method for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->