### PR TITLE
Use package name as basename for Thor classes

### DIFF
--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -31,25 +31,7 @@ at_exit do
   end
 end
 
-# Fix for https://github.com/erikhuda/thor/issues/398
-# Copied from https://github.com/rails/thor/issues/398#issuecomment-622988390
-class Thor
-  module Shell
-    class Basic
-      def print_wrapped(message, options = {})
-        indent = (options[:indent] || 0).to_i
-        if indent.zero?
-          stdout.puts(message)
-        else
-          message.each_line do |message_line|
-            stdout.print(" " * indent)
-            stdout.puts(message_line.chomp)
-          end
-        end
-      end
-    end
-  end
-end
+require_relative "patches/thor"
 
 module Cpflow
   class Error < StandardError; end

--- a/lib/patches/thor.rb
+++ b/lib/patches/thor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Thor
+  # Fix for https://github.com/erikhuda/thor/issues/398
+  # Copied from https://github.com/rails/thor/issues/398#issuecomment-622988390
+  module Shell
+    class Basic
+      def print_wrapped(message, options = {})
+        indent = (options[:indent] || 0).to_i
+        if indent.zero?
+          stdout.puts(message)
+        else
+          message.each_line do |message_line|
+            stdout.print(" " * indent)
+            stdout.puts(message_line.chomp)
+          end
+        end
+      end
+    end
+  end
+
+  # Fix for https://github.com/rails/thor/issues/742
+  def self.basename
+    @package_name || super
+  end
+end

--- a/spec/patches/thor_spec.rb
+++ b/spec/patches/thor_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "thor"
+require "patches/thor"
+
+describe Thor do
+  describe ".basename" do
+    subject(:basename) { klass.send(:basename) }
+
+    context "when class has defined package name" do
+      let(:klass) do
+        Class.new(described_class) do
+          package_name "test_package_name"
+        end
+      end
+
+      it "returns package name" do
+        expect(basename).to eq("test_package_name")
+      end
+    end
+
+    context "when class doesn't have defined package name" do
+      let(:klass) { Class.new(described_class) }
+
+      it "returns basename of program invoking the class" do
+        expect(basename).to eq("rspec")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

This PR:
1. Fixes `Thor.basename` so it prefers `@package_name` over basename of `$PROGRAM_NAME`
2. Moves monkey patches for `Thor` class to separate file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced message formatting capabilities through a new `print_wrapped` method in the `Thor` class.
	- Improved flexibility of the `basename` method in the `Thor` class for better context utilization.
  
- **Bug Fixes**
	- Resolved issues with the `basename` method to ensure it correctly returns the package name or default program name.

- **Tests**
	- Added comprehensive tests for the `.basename` method to validate its behavior in different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->