### PR TITLE
Update min `cpln` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ _Please add entries here for your pull requests that have not yet been released.
 - Fixed issue where common options are not forwarded to other commands. [PR 207](https://github.com/shakacode/control-plane-flow/pull/207) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 - Fixed BYOK endpoint. [PR 209](https://github.com/shakacode/control-plane-flow/pull/209) by [Sergey Tarasov](https://github.com/dzirtusss).
 - Fixed issue where `generate` command fails if no project config exists. [PR 219](https://github.com/shakacode/control-plane-flow/pull/219) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
+- Bumped min `cpln` version to `3.1.0` and fixed `cpln workload exec` calls. [PR 226](https://github.com/shakacode/control-plane-flow/pull/226) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [3.0.1] - 2024-06-26
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -243,7 +243,7 @@ module Command
 
       step("Updating runner workload '#{runner_workload}'") do
         # Update runner workload
-        @expected_deployed_version = cp.cron_workload_deployed_version(runner_workload) + 1
+        @expected_deployed_version = (cp.cron_workload_deployed_version(runner_workload) || 0) + 1
         cp.apply_hash("kind" => "workload", "name" => runner_workload, "spec" => spec)
       end
     end
@@ -256,7 +256,7 @@ module Command
 
     def wait_for_runner_workload_update
       step("Waiting for runner workload '#{runner_workload}' to be updated", retry_on_failure: true) do
-        cp.cron_workload_deployed_version(runner_workload) >= expected_deployed_version
+        (cp.cron_workload_deployed_version(runner_workload) || 0) >= expected_deployed_version
       end
     end
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -277,7 +277,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def workload_exec(workload, replica, location:, container: nil, command: nil)
-    cmd = "cpln workload exec #{workload} #{gvc_org} --replica #{replica} --location #{location}"
+    cmd = "cpln workload exec #{workload} #{gvc_org} --replica #{replica} --location #{location} -it"
     cmd += " --container #{container}" if container
     cmd += " -- #{command}"
     perform!(cmd, output_mode: :all)

--- a/lib/cpflow/version.rb
+++ b/lib/cpflow/version.rb
@@ -2,5 +2,5 @@
 
 module Cpflow
   VERSION = "3.0.1"
-  MIN_CPLN_VERSION = "2.0.1"
+  MIN_CPLN_VERSION = "3.1.0"
 end

--- a/spec/command/delete_spec.rb
+++ b/spec/command/delete_spec.rb
@@ -70,16 +70,9 @@ describe Command::Delete do
       run_cpflow_command!("build-image", "-a", app)
     end
 
-    after do
-      run_cpflow_command!("delete", "-a", app, "--yes")
-    end
-
     it "deletes app with volumesets and images", :slow do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      result = run_cpflow_command("delete", "-a", app)
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting volumeset 'detached-volume' from app '#{app}'[.]+? done!/)
       expect(result[:stderr]).to match(/Deleting volumeset 'postgres-volume' from app '#{app}'[.]+? done!/)
@@ -157,11 +150,8 @@ describe Command::Delete do
     end
 
     it "does not unbind identity from policy" do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      result = run_cpflow_command("delete", "-a", app)
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
       expect(result[:stderr]).not_to include("Unbinding identity from policy")
@@ -176,11 +166,8 @@ describe Command::Delete do
     end
 
     it "does not unbind identity from policy" do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      result = run_cpflow_command("delete", "-a", app)
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
       expect(result[:stderr]).not_to include("Unbinding identity from policy")
@@ -195,11 +182,8 @@ describe Command::Delete do
     end
 
     it "does not unbind identity from policy" do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      result = run_cpflow_command("delete", "-a", app)
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
       expect(result[:stderr]).not_to include("Unbinding identity from policy")
@@ -214,11 +198,8 @@ describe Command::Delete do
     end
 
     it "unbinds identity from policy" do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      result = run_cpflow_command("delete", "-a", app)
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(/Deleting app '#{app}'[.]+? done!/)
       expect(result[:stderr]).to match(/Unbinding identity from policy for app '#{app}'[.]+? done!/)
@@ -238,14 +219,11 @@ describe Command::Delete do
     end
 
     it "fails to run hook", :slow do
-      result = nil
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      spawn_cpflow_command("delete", "-a", app, "--yes") do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running pre-deletion hook")
-      expect(result).to include("Failed to run pre-deletion hook")
+      expect(result[:status]).not_to eq(0)
+      expect(result[:stderr]).to include("Running pre-deletion hook")
+      expect(result[:stderr]).to include("Failed to run pre-deletion hook")
     end
   end
 
@@ -258,14 +236,11 @@ describe Command::Delete do
     end
 
     it "successfully runs hook", :slow do
-      result = nil
+      result = run_cpflow_command("delete", "-a", app, "--yes")
 
-      spawn_cpflow_command("delete", "-a", app, "--yes") do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running pre-deletion hook")
-      expect(result).to include("Finished running pre-deletion hook")
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("Running pre-deletion hook")
+      expect(result[:stderr]).to include("Finished running pre-deletion hook")
     end
   end
 
@@ -277,11 +252,8 @@ describe Command::Delete do
     end
 
     it "does not run hook" do
-      allow(Shell).to receive(:confirm).with(include(app)).and_return(true)
+      result = run_cpflow_command("delete", "-a", app, "--yes", "--skip-pre-deletion-hook")
 
-      result = run_cpflow_command("delete", "-a", app, "--skip-pre-deletion-hook")
-
-      expect(Shell).to have_received(:confirm).once
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).not_to include("Running pre-deletion hook")
     end

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -106,4 +106,19 @@ describe Command::DeployImage do
       expect(result[:stderr]).not_to include("- rails-with-non-app-image:")
     end
   end
+
+  context "when workload uses BYOK location" do
+    let!(:app) { dummy_test_app("rails-non-app-image", create_if_not_exists: true) }
+
+    before do
+      allow(Resolv).to receive(:getaddress).and_raise(Resolv::ResolvError)
+    end
+
+    it "lists correct endpoint", :slow do
+      result = run_cpflow_command("deploy-image", "-a", app)
+
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(%r{- rails: https://rails-.+?.controlplane.us})
+    end
+  end
 end

--- a/spec/command/deploy_image_spec.rb
+++ b/spec/command/deploy_image_spec.rb
@@ -76,15 +76,12 @@ describe Command::DeployImage do
     end
 
     it "fails to run release script and fails to deploy image", :slow do
-      result = nil
+      result = run_cpflow_command("deploy-image", "-a", app, "--run-release-phase")
 
-      spawn_cpflow_command("deploy-image", "-a", app, "--run-release-phase") do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running release script")
-      expect(result).to include("Failed to run release script")
-      expect(result).not_to include("- rails:")
+      expect(result[:status]).not_to eq(0)
+      expect(result[:stderr]).to include("Running release script")
+      expect(result[:stderr]).to include("Failed to run release script")
+      expect(result[:stderr]).not_to include("- rails:")
     end
   end
 
@@ -100,16 +97,13 @@ describe Command::DeployImage do
     end
 
     it "runs release script and deploys image", :slow do
-      result = nil
+      result = run_cpflow_command("deploy-image", "-a", app, "--run-release-phase")
 
-      spawn_cpflow_command("deploy-image", "-a", app, "--run-release-phase") do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running release script")
-      expect(result).to include("Finished running release script")
-      expect(result).to match(%r{- rails: https://rails-.+?.cpln.app})
-      expect(result).not_to include("- rails-with-non-app-image:")
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("Running release script")
+      expect(result[:stderr]).to include("Finished running release script")
+      expect(result[:stderr]).to match(%r{- rails: https://rails-.+?.cpln.app})
+      expect(result[:stderr]).not_to include("- rails-with-non-app-image:")
     end
   end
 end

--- a/spec/command/promote_app_from_upstream_spec.rb
+++ b/spec/command/promote_app_from_upstream_spec.rb
@@ -57,17 +57,14 @@ describe Command::PromoteAppFromUpstream do
     end
 
     it "copies latest image from upstream, fails to run release script and fails to deploy image", :slow do
-      result = nil
+      result = run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
 
-      spawn_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
-      expect(result).to match(%r{Pushing image to '.+?/#{app}:1'})
-      expect(result).to include("Running release script")
-      expect(result).to include("Failed to run release script")
-      expect(result).not_to match(%r{rails: https://rails-.+?.cpln.app})
+      expect(result[:status]).not_to eq(0)
+      expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
+      expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
+      expect(result[:stderr]).to include("Running release script")
+      expect(result[:stderr]).to include("Failed to run release script")
+      expect(result[:stderr]).not_to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end
 
@@ -94,17 +91,14 @@ describe Command::PromoteAppFromUpstream do
     end
 
     it "copies latest image from upstream, runs release script and deploys image", :slow do
-      result = nil
+      result = run_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token)
 
-      spawn_cpflow_command("promote-app-from-upstream", "-a", app, "--upstream-token", token) do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
-      expect(result).to match(%r{Pushing image to '.+?/#{app}:1'})
-      expect(result).to include("Running release script")
-      expect(result).to include("Finished running release script")
-      expect(result).to match(%r{rails: https://rails-.+?.cpln.app})
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to match(%r{Pulling image from '.+?/#{upstream_app}:1'})
+      expect(result[:stderr]).to match(%r{Pushing image to '.+?/#{app}:1'})
+      expect(result[:stderr]).to include("Running release script")
+      expect(result[:stderr]).to include("Finished running release script")
+      expect(result[:stderr]).to match(%r{rails: https://rails-.+?.cpln.app})
     end
   end
 end

--- a/spec/command/run_spec.rb
+++ b/spec/command/run_spec.rb
@@ -89,44 +89,35 @@ describe Command::Run do
       let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
       it "clones workload and runs provided command with success", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "ls") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).not_to include("Updating runner workload")
-        expect(result).to include("Gemfile")
-        expect(result).to include("[#{Shell.color('JOB STATUS', :red)}] successful")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).not_to include("Updating runner workload")
+        expect(result[:stderr]).to include("Gemfile")
+        expect(result[:stderr]).to include("[JOB STATUS] successful")
       end
 
       it "clones workload and runs provided command with failure", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "nonexistent")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "nonexistent") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).not_to include("Gemfile")
-        expect(result).to include("[#{Shell.color('JOB STATUS', :red)}] failed")
+        expect(result[:status]).not_to eq(0)
+        expect(result[:stderr]).not_to include("Gemfile")
+        expect(result[:stderr]).to include("[JOB STATUS] failed")
       end
 
       it "waits for job to finish", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "sleep 10; ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--verbose", "--", "'sleep 10; ls'") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("Gemfile")
-        expect(result).to include("[#{Shell.color('JOB STATUS', :red)}] active")
-        expect(result).to include("[#{Shell.color('JOB STATUS', :red)}] successful")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("Gemfile")
+        expect(result[:stderr]).to include("[JOB STATUS] active")
+        expect(result[:stderr]).to include("[JOB STATUS] successful")
       end
     end
 
     context "when not specifying image" do
       let!(:app) { dummy_test_app }
-      let!(:cmd) { "'echo $CPLN_IMAGE'" }
+      let!(:cmd) { "echo $CPLN_IMAGE" }
 
       before do
         run_cpflow_command!("apply-template", "app", "rails", "-a", app)
@@ -140,69 +131,52 @@ describe Command::Run do
       end
 
       it "clones workload and runs with exact same image as original workload after running with latest image", :slow do
-        result1 = nil
-        result2 = nil
+        result1 = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd)
+        result2 = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd)
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
-          result1 = it.read_full_output
-        end
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
-          result2 = it.read_full_output
-        end
-
-        expect(result1).to match(%r{/org/.+?/image/#{app}:2})
-        expect(result2).to match(%r{/org/.+?/image/#{app}:1})
+        expect(result1[:status]).to eq(0)
+        expect(result2[:status]).to eq(0)
+        expect(result1[:stderr]).to match(%r{/org/.+?/image/#{app}:2})
+        expect(result2[:stderr]).to match(%r{/org/.+?/image/#{app}:1})
       end
     end
 
     context "when specifying image" do
       let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
-      let!(:cmd) { "'echo $CPLN_IMAGE'" }
+      let!(:cmd) { "echo $CPLN_IMAGE" }
 
       it "clones workload and runs with latest image", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd)
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "latest", "--", cmd) do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to match(%r{/org/.+?/image/#{app}:2})
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to match(%r{/org/.+?/image/#{app}:2})
       end
 
       it "clones workload and runs with specific image", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "#{app}:1", "--", cmd)
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--image", "#{app}:1", "--", cmd) do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to match(%r{/org/.+?/image/#{app}:1})
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to match(%r{/org/.+?/image/#{app}:1})
       end
     end
 
     context "when specifying token" do
       let!(:token) { Shell.cmd("cpln", "profile", "token", "default")[:output].strip }
       let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
-      let!(:cmd) { "'if [ \"$CPLN_TOKEN\" = \"#{token}\" ]; then echo \"LOCAL\"; else echo \"REMOTE\"; fi'" }
+      let!(:cmd) { "if [ \"$CPLN_TOKEN\" = \"#{token}\" ]; then echo \"LOCAL\"; else echo \"REMOTE\"; fi" }
 
       it "clones workload and runs with remote token", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd)
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", cmd) do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("REMOTE")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("REMOTE")
       end
 
       it "clones workload and runs with local token", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--use-local-token", "--", cmd)
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--use-local-token", "--", cmd) do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("LOCAL")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("LOCAL")
       end
     end
 
@@ -220,13 +194,10 @@ describe Command::Run do
       end
 
       it "clones workload and times out before finishing", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "sleep 100; ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "'sleep 100; ls'") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).not_to include("Gemfile")
+        expect(result[:status]).not_to eq(0)
+        expect(result[:stderr]).not_to include("Gemfile")
       end
     end
 
@@ -234,14 +205,11 @@ describe Command::Run do
       let!(:app) { dummy_test_app("full", create_if_not_exists: true) }
 
       it "prints commands to log and stop the job", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--detached", "--", "ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--detached", "--", "ls") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("cpflow logs")
-        expect(result).to include("cpflow ps:stop")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("cpflow logs")
+        expect(result[:stderr]).to include("cpflow ps:stop")
       end
     end
 
@@ -257,14 +225,11 @@ describe Command::Run do
       end
 
       it "updates runner workload", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("Updating runner workload")
-        expect(result).to include("Gemfile")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("Updating runner workload")
+        expect(result[:stderr]).to include("Gemfile")
       end
     end
 
@@ -280,14 +245,11 @@ describe Command::Run do
       end
 
       it "updates runner workload", :slow do
-        result = nil
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls")
 
-        spawn_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls") do |it|
-          result = it.read_full_output
-        end
-
-        expect(result).to include("Updating runner workload")
-        expect(result).to include("Gemfile")
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("Updating runner workload")
+        expect(result[:stderr]).to include("Gemfile")
       end
     end
   end

--- a/spec/command/setup_app_spec.rb
+++ b/spec/command/setup_app_spec.rb
@@ -109,14 +109,11 @@ describe Command::SetupApp do
     end
 
     it "fails to run hook", :slow do
-      result = nil
+      result = run_cpflow_command("setup-app", "-a", app)
 
-      spawn_cpflow_command("setup-app", "-a", app) do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running post-creation hook")
-      expect(result).to include("Failed to run post-creation hook")
+      expect(result[:status]).not_to eq(0)
+      expect(result[:stderr]).to include("Running post-creation hook")
+      expect(result[:stderr]).to include("Failed to run post-creation hook")
     end
   end
 
@@ -132,14 +129,11 @@ describe Command::SetupApp do
     end
 
     it "successfully runs hook", :slow do
-      result = nil
+      result = run_cpflow_command("setup-app", "-a", app)
 
-      spawn_cpflow_command("setup-app", "-a", app) do |it|
-        result = it.read_full_output
-      end
-
-      expect(result).to include("Running post-creation hook")
-      expect(result).to include("Finished running post-creation hook")
+      expect(result[:status]).to eq(0)
+      expect(result[:stderr]).to include("Running post-creation hook")
+      expect(result[:stderr]).to include("Finished running post-creation hook")
     end
   end
 

--- a/spec/support/command_helpers.rb
+++ b/spec/support/command_helpers.rb
@@ -191,13 +191,14 @@ module CommandHelpers # rubocop:disable Metrics/ModuleLength
     run_cpflow_command(*args, raise_errors: true)
   end
 
-  def spawn_cpflow_command(*args, stty_rows: nil, stty_cols: nil, wait_for_process: true)
+  def spawn_cpflow_command(*args, stty_rows: nil, stty_cols: nil, wait_for_process: true) # rubocop:disable Metrics/MethodLength
     cmd = ""
     cmd += "stty rows #{stty_rows} && " if stty_rows
     cmd += "stty cols #{stty_cols} && " if stty_cols
     cmd += "#{cpflow_executable_with_simplecov} #{args.join(' ')}"
 
     LogHelpers.write_command_to_log(cmd)
+    LogHelpers.write_section_separator_to_log
 
     PTY.spawn(cmd) do |output, input, pid|
       yield(SpawnedCommand.new(output, input, pid))

--- a/spec/support/spawned_command.rb
+++ b/spec/support/spawned_command.rb
@@ -15,26 +15,13 @@ class SpawnedCommand
     @pid = pid
   end
 
-  def read_full_output
-    LogHelpers.write_section_separator_to_log
-
-    full_output = ""
-    output.each do |line|
-      full_output += line
-
-      LogHelpers.write_line_to_log(line)
-    end
-
-    full_output
-  rescue Errno::EIO
-    full_output
-  end
-
   def wait_for(regex, timeout: DEFAULT_TIMEOUT)
     result = nil
     output.expect(regex, timeout) do |matches|
       result = matches&.first
     end
+
+    LogHelpers.write_line_to_log(result)
 
     raise "Timed out waiting for #{regex.inspect} after #{timeout} seconds" if result.nil?
 


### PR DESCRIPTION
* Bumps min `cpln` version to `3.1.0`
* Fixes `cpln workload exec` calls accordingly
* Fixes specs

**Note:** Ran all specs locally and they all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced command execution with interactive terminal support for improved user experience.
	- Updated minimum required version for `Cpflow` module compatibility to version 3.1.0.

- **Bug Fixes**
	- Improved handling of nil values in workload version calculations to prevent errors during workload updates.

- **Tests**
	- Refactored test cases for clarity and maintainability, focusing on structured output verification and simplified command execution.

- **Chores**
	- Improved logging functionality to enhance readability and organization of logged commands.
	- Added a changelog entry for the update on the `cpln` package version and related fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->