### PR TITLE
Fix issue where `run` command fails when runner workload has ENV but original workload does not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Fixed
+
+- Fixed issue where `run` command fails when runner workload has ENV but original workload does not. [PR 227](https://github.com/shakacode/control-plane-flow/pull/227) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
 
 ## [4.0.0] - 2024-08-21
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -465,21 +465,12 @@ module Command
       $stderr
     end
 
-    def step_error(error, abort_on_error: true)
-      message = error.message
-      if abort_on_error
-        progress.puts(" #{Shell.color('failed!', :red)}\n\n")
-        Shell.abort(message)
-      else
-        Shell.write_to_tmp_stderr(message)
-      end
-    end
-
-    def step_finish(success)
+    def step_finish(success, abort_on_error: true)
       if success
         progress.puts(" #{Shell.color('done!', :green)}")
       else
         progress.puts(" #{Shell.color('failed!', :red)}\n\n#{Shell.read_from_tmp_stderr}\n\n")
+        exit(ExitCode::ERROR_DEFAULT) if abort_on_error
       end
     end
 
@@ -499,10 +490,10 @@ module Command
             success = yield
           end
         rescue RuntimeError => e
-          step_error(e, abort_on_error: abort_on_error)
+          Shell.write_to_tmp_stderr(e.message)
         end
 
-        step_finish(success)
+        step_finish(success, abort_on_error: abort_on_error)
       end
     end
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -207,7 +207,7 @@ module Command
         original_env_str = original_container_spec["env"]&.sort_by { |env| env["name"] }.to_s
         env_str = container_spec["env"]&.sort_by { |env| env["name"] }.to_s
         if original_env_str != env_str
-          container_spec["env"] = original_container_spec["env"]
+          container_spec["env"] = original_container_spec["env"] || []
           should_update = true
         end
 

--- a/spec/command/run_spec.rb
+++ b/spec/command/run_spec.rb
@@ -252,5 +252,27 @@ describe Command::Run do
         expect(result[:stderr]).to include("Gemfile")
       end
     end
+
+    context "when runner workload has ENV but original workload does not" do
+      let!(:app) { dummy_test_app }
+
+      before do
+        run_cpflow_command!("apply-template", "app", "rails", "rails-runner-with-different-env", "-a", app)
+        run_cpflow_command!("build-image", "-a", app)
+        run_cpflow_command!("deploy-image", "-a", app)
+      end
+
+      after do
+        run_cpflow_command!("delete", "-a", app, "--yes")
+      end
+
+      it "updates runner workload", :slow do
+        result = run_cpflow_command("run", "-a", app, "--entrypoint", "none", "--", "ls")
+
+        expect(result[:status]).to eq(0)
+        expect(result[:stderr]).to include("Updating runner workload")
+        expect(result[:stderr]).to include("Gemfile")
+      end
+    end
   end
 end


### PR DESCRIPTION
New spec is [passing](https://github.com/shakacode/control-plane-flow/actions/runs/10507161397/job/29108310758).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved an issue with the `run` command failing when environment variables differ between workloads, enhancing command robustness.

- **Tests**
	- Expanded test coverage for the command-line runner to validate behavior when environment variables are set for the runner workload but not for the original workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->