### PR TITLE
Maintenance mode: check if domain is updated via API

### DIFF
--- a/lib/core/maintenance_mode.rb
+++ b/lib/core/maintenance_mode.rb
@@ -84,9 +84,13 @@ class MaintenanceMode
   def switch_domain_workload(to:)
     step("Switching workload for domain '#{domain_data['name']}' to '#{to}'") do
       cp.set_domain_workload(domain_data, to)
+    end
 
-      # Give it a bit of time for the domain to update
-      Kernel.sleep(30)
+    step("Waiting for changes to take effect", retry_on_failure: true, wait: 10, max_retry_count: 3) do
+      refetched_domain_data = cp.fetch_domain(domain_data["name"])
+      raise "Can't find domain" if refetched_domain_data.nil?
+
+      cp.domain_workload_matches?(refetched_domain_data, to)
     end
 
     progress.puts


### PR DESCRIPTION
### What does this PR do?

This PR replaces `sleep` with actual API request to check if `workloadLink` is changed for domain after update

### Tests

Specs for maintenance command are passing - https://github.com/shakacode/control-plane-flow/actions/runs/10626502289/job/29458117242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced the maintenance workload switching process with a dynamic retry mechanism for improved responsiveness.
	- Introduced error handling to ensure domain availability during workload switches.

- **Bug Fixes**
	- Replaced static wait time with a more efficient verification approach to confirm the workload state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->