### PR TITLE
Create GVC and identity terraform configs from templates

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -449,7 +449,7 @@ cpflow setup-app -a $APP_NAME
 - Generates terraform configuration files based on `controlplane.yml` and `templates/` config
 
 ```sh
-cpflow terraform generate
+cpflow terraform generate -a $APP_NAME
 ```
 
 ### `version`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -449,7 +449,7 @@ cpflow setup-app -a $APP_NAME
 - Generates terraform configuration files based on `controlplane.yml` and `templates/` config
 
 ```sh
-cpflow terraform generate -a $APP_NAME
+cpflow terraform generate
 ```
 
 ### `version`

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -454,6 +454,19 @@ module Command
         }
       }
     end
+
+    def self.dir_option(required: false)
+      {
+        name: :dir,
+        params: {
+          banner: "DIR",
+          desc: "Output directory",
+          type: :string,
+          required: required
+        }
+      }
+    end
+
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -5,15 +5,26 @@ module Command
     class Generate < Base
       SUBCOMMAND_NAME = "terraform"
       NAME = "generate"
+      OPTIONS = [
+        app_option(required: true)
+      ].freeze
       DESCRIPTION = "Generates terraform configuration files"
       LONG_DESCRIPTION = <<~DESC
         - Generates terraform configuration files based on `controlplane.yml` and `templates/` config
       DESC
       WITH_INFO_HEADER = false
-      VALIDATIONS = [].freeze
 
       def call
         File.write(terraform_dir.join("providers.tf"), cpln_provider.to_tf)
+
+        templates.each do |template|
+          generator = TerraformConfig::Generator.new(config: config, template: template)
+
+          # TODO: Delete line below after all template kinds are supported
+          next unless %w[gvc identity].include?(template["kind"])
+
+          File.write(terraform_dir.join(generator.filename), generator.tf_config.to_tf, mode: "a+")
+        end
       end
 
       private
@@ -22,8 +33,14 @@ module Command
         TerraformConfig::RequiredProvider.new("cpln", source: "controlplane-com/cpln", version: "~> 1.0")
       end
 
+      def templates
+        parser = TemplateParser.new(self)
+        parser.parse(Dir["#{parser.template_dir}/*.yml"])
+      end
+
       def terraform_dir
         @terraform_dir ||= Cpflow.root_path.join("terraform").tap do |path|
+          FileUtils.rm_rf(path)
           FileUtils.mkdir_p(path)
         end
       end

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -6,7 +6,8 @@ module Command
       SUBCOMMAND_NAME = "terraform"
       NAME = "generate"
       OPTIONS = [
-        app_option(required: true)
+        app_option(required: false),
+        dir_option(required: false)
       ].freeze
       DESCRIPTION = "Generates terraform configuration files"
       LONG_DESCRIPTION = <<~DESC
@@ -15,7 +16,32 @@ module Command
       WITH_INFO_HEADER = false
 
       def call
+        generate_common_configs
+        generate_app_configs
+      end
+
+      private
+
+      def generate_common_configs
+        cpln_provider = TerraformConfig::RequiredProvider.new(
+          "cpln",
+          source: "controlplane-com/cpln",
+          version: "~> 1.0"
+        )
+
         File.write(terraform_dir.join("providers.tf"), cpln_provider.to_tf)
+      end
+
+      def generate_app_configs
+        Array(config.app || config.apps.keys).each do |app|
+          generate_app_config(app.to_s)
+        end
+      end
+
+      def generate_app_config(app)
+        config.class.define_method(:app) { app }
+
+        terraform_app_dir = recreate_terraform_app_dir(app)
 
         templates.each do |template|
           generator = TerraformConfig::Generator.new(config: config, template: template)
@@ -23,14 +49,17 @@ module Command
           # TODO: Delete line below after all template kinds are supported
           next unless %w[gvc identity].include?(template["kind"])
 
-          File.write(terraform_dir.join(generator.filename), generator.tf_config.to_tf, mode: "a+")
+          File.write(terraform_app_dir.join(generator.filename), generator.tf_config.to_tf, mode: "a+")
         end
       end
 
-      private
+      def recreate_terraform_app_dir(app_path)
+        full_path = terraform_dir.join(app_path)
 
-      def cpln_provider
-        TerraformConfig::RequiredProvider.new("cpln", source: "controlplane-com/cpln", version: "~> 1.0")
+        FileUtils.rm_rf(full_path)
+        FileUtils.mkdir_p(full_path)
+
+        full_path
       end
 
       def templates
@@ -39,9 +68,9 @@ module Command
       end
 
       def terraform_dir
-        @terraform_dir ||= Cpflow.root_path.join("terraform").tap do |path|
-          FileUtils.rm_rf(path)
-          FileUtils.mkdir_p(path)
+        @terraform_dir ||= begin
+          full_path = config.options.fetch(:dir, Cpflow.root_path.join("terraform"))
+          Pathname.new(full_path).tap { |path| FileUtils.mkdir_p(path) }
         end
       end
     end

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -64,7 +64,17 @@ module Command
 
       def templates
         parser = TemplateParser.new(self)
-        parser.parse(Dir["#{parser.template_dir}/*.yml"])
+        template_files = Dir["#{parser.template_dir}/*.yml"]
+
+        if template_files.empty?
+          Shell.warn "No templates found in #{parser.template_dir}"
+          return []
+        end
+
+        parser.parse(template_files)
+      rescue StandardError => e
+        Shell.warn "Error parsing templates: #{e.message}"
+        []
       end
 
       def terraform_dir

--- a/lib/command/terraform/generate.rb
+++ b/lib/command/terraform/generate.rb
@@ -56,6 +56,10 @@ module Command
       def recreate_terraform_app_dir(app_path)
         full_path = terraform_dir.join(app_path)
 
+        unless File.expand_path(full_path).include?(Cpflow.root_path.to_s)
+          Shell.abort("Directory to save terraform configuration files cannot be outside of current directory")
+        end
+
         FileUtils.rm_rf(full_path)
         FileUtils.mkdir_p(full_path)
 
@@ -80,7 +84,11 @@ module Command
       def terraform_dir
         @terraform_dir ||= begin
           full_path = config.options.fetch(:dir, Cpflow.root_path.join("terraform"))
-          Pathname.new(full_path).tap { |path| FileUtils.mkdir_p(path) }
+          Pathname.new(full_path).tap do |path|
+            FileUtils.mkdir_p(path)
+          rescue StandardError => e
+            Shell.abort("Invalid directory: #{e.message}")
+          end
         end
       end
     end

--- a/lib/core/terraform_config/dsl.rb
+++ b/lib/core/terraform_config/dsl.rb
@@ -4,6 +4,8 @@ module TerraformConfig
   module Dsl
     extend Forwardable
 
+    REFERENCE_PATTERN = /^(var|locals|cpln_\w+)\./.freeze
+
     def_delegators :current_context, :put, :output
 
     def block(name, *labels)
@@ -44,7 +46,7 @@ module TerraformConfig
     end
 
     def expression?(value)
-      value.start_with?("var.") || value.start_with?("locals.")
+      value.match?(REFERENCE_PATTERN)
     end
 
     def block_declaration(name, labels)
@@ -62,7 +64,7 @@ module TerraformConfig
       end
 
       def put(content, indent: 0)
-        @output += content.indent(indent)
+        @output += content.to_s.indent(indent)
       end
     end
 

--- a/lib/core/terraform_config/generator.rb
+++ b/lib/core/terraform_config/generator.rb
@@ -33,8 +33,7 @@ module TerraformConfig
 
     private
 
-    # rubocop:disable Metrics/MethodLength
-    def gvc_config
+    def gvc_config # rubocop:disable Metrics/MethodLength
       pull_secrets = template.dig("spec", "pullSecretLinks")&.map do |secret_link|
         secret_name = secret_link.split("/").last
         "cpln_secret.#{secret_name}.name"
@@ -53,7 +52,6 @@ module TerraformConfig
         load_balancer: load_balancer
       )
     end
-    # rubocop:enable Metrics/MethodLength
 
     def identity_config
       TerraformConfig::Identity.new(

--- a/lib/core/terraform_config/generator.rb
+++ b/lib/core/terraform_config/generator.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module TerraformConfig
+  class Generator
+    attr_reader :config, :template
+
+    def initialize(config:, template:)
+      @config = config
+      @template = template
+    end
+
+    def filename
+      case template["kind"]
+      when "gvc"
+        "gvc.tf"
+      when "identity"
+        "identities.tf"
+      else
+        raise "Unsupported template kind - #{template['kind']}"
+      end
+    end
+
+    def tf_config
+      case template["kind"]
+      when "gvc"
+        gvc_config
+      when "identity"
+        identity_config
+      else
+        raise "Unsupported template kind - #{template['kind']}"
+      end
+    end
+
+    private
+
+    # rubocop:disable Metrics/MethodLength
+    def gvc_config
+      pull_secrets = template.dig("spec", "pullSecretLinks")&.map do |secret_link|
+        secret_name = secret_link.split("/").last
+        "cpln_secret.#{secret_name}.name"
+      end
+
+      load_balancer = template.dig("spec", "loadBalancer")
+
+      TerraformConfig::Gvc.new(
+        name: template["name"],
+        description: template["description"],
+        tags: template["tags"],
+        domain: template.dig("spec", "domain"),
+        env: env,
+        pull_secrets: pull_secrets,
+        locations: locations,
+        load_balancer: load_balancer
+      )
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def identity_config
+      TerraformConfig::Identity.new(
+        gvc: "cpln_gvc.#{config.app}.name", # GVC name matches application name
+        name: template["name"],
+        description: template["description"],
+        tags: template["tags"]
+      )
+    end
+
+    def env
+      template.dig("spec", "env").to_h { |env_var| [env_var["name"], env_var["value"]] }
+    end
+
+    def locations
+      template.dig("spec", "staticPlacement", "locationLinks")&.map do |location_link|
+        location_link.split("/").last
+      end
+    end
+  end
+end

--- a/lib/core/terraform_config/gvc.rb
+++ b/lib/core/terraform_config/gvc.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module TerraformConfig
+  class Gvc < Base
+    attr_reader :name, :description, :tags, :domain, :locations, :pull_secrets, :env, :load_balancer
+
+    # rubocop:disable Metrics/ParameterLists
+    def initialize(
+      name:,
+      description: nil,
+      tags: nil,
+      domain: nil,
+      locations: nil,
+      pull_secrets: nil,
+      env: nil,
+      load_balancer: nil
+    )
+      super()
+
+      @name = name
+      @description = description
+      @tags = tags
+      @domain = domain
+      @locations = locations
+      @pull_secrets = pull_secrets
+      @env = env
+      @load_balancer = load_balancer&.transform_keys { |k| k.to_s.underscore.to_sym }
+    end
+    # rubocop:enable Metrics/ParameterLists
+
+    def to_tf
+      block :resource, :cpln_gvc, name do
+        argument :name, name
+        argument :description, description, optional: true
+        argument :tags, tags, optional: true
+
+        argument :domain, domain, optional: true
+        argument :locations, locations, optional: true
+        argument :pull_secrets, pull_secrets, optional: true
+        argument :env, env, optional: true
+
+        load_balancer_tf
+      end
+    end
+
+    private
+
+    def load_balancer_tf
+      return if load_balancer.nil?
+
+      block :load_balancer do
+        argument :dedicated, load_balancer.fetch(:dedicated)
+        argument :trusted_proxies, load_balancer.fetch(:trusted_proxies, nil), optional: true
+      end
+    end
+  end
+end

--- a/lib/core/terraform_config/gvc.rb
+++ b/lib/core/terraform_config/gvc.rb
@@ -4,8 +4,7 @@ module TerraformConfig
   class Gvc < Base
     attr_reader :name, :description, :tags, :domain, :locations, :pull_secrets, :env, :load_balancer
 
-    # rubocop:disable Metrics/ParameterLists
-    def initialize(
+    def initialize( # rubocop:disable Metrics/ParameterLists
       name:,
       description: nil,
       tags: nil,
@@ -26,7 +25,6 @@ module TerraformConfig
       @env = env
       @load_balancer = load_balancer&.transform_keys { |k| k.to_s.underscore.to_sym }
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def to_tf
       block :resource, :cpln_gvc, name do

--- a/lib/core/terraform_config/identity.rb
+++ b/lib/core/terraform_config/identity.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module TerraformConfig
+  class Identity < Base
+    attr_reader :gvc, :name, :description, :tags
+
+    def initialize(gvc:, name:, description: nil, tags: nil)
+      super()
+
+      @gvc = gvc
+      @name = name
+      @description = description
+      @tags = tags
+    end
+
+    def to_tf
+      block :resource, :cpln_identity, name do
+        argument :gvc, gvc
+
+        argument :name, name
+        argument :description, description, optional: true
+
+        argument :tags, tags, optional: true
+      end
+    end
+  end
+end

--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -235,7 +235,7 @@ module Cpflow
         long_desc(long_description)
 
         command_options.each do |option|
-          params = process_option_params(option[:params])
+          params = Cpflow::Cli.process_option_params(option[:params])
           method_option(option[:name], **params)
         end
       end

--- a/lib/patches/string.rb
+++ b/lib/patches/string.rb
@@ -17,5 +17,9 @@ class String
   def unindent
     gsub(/^#{scan(/^[ \t]+(?=\S)/).min}/, "")
   end
+
+  def underscore
+    gsub(/(.)([A-Z])/, '\1_\2').downcase
+  end
 end
 # rubocop:enable Style/OptionalBooleanParameter, Lint/UnderscorePrefixedVariableName

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -36,9 +36,7 @@ describe Command::Terraform::Generate do
     let(:template_dir) { "non-existing-folder" }
 
     before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(TemplateParser).to receive(:template_dir).and_return(template_dir)
-      # rubocop:enable RSpec/AnyInstance
+      allow_any_instance_of(TemplateParser).to receive(:template_dir).and_return(template_dir) # rubocop:disable RSpec/AnyInstance
     end
 
     it "generates only common config files" do
@@ -53,9 +51,7 @@ describe Command::Terraform::Generate do
 
   context "when template parsing fails" do
     before do
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(TemplateParser).to receive(:parse).and_raise("error")
-      # rubocop:enable RSpec/AnyInstance
+      allow_any_instance_of(TemplateParser).to receive(:parse).and_raise("error") # rubocop:disable RSpec/AnyInstance
     end
 
     it "generates only common config files" do

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -9,6 +9,8 @@ GENERATOR_PLAYGROUND_PATH = GEM_TEMP_PATH.join("sample-project")
 TERRAFORM_CONFIG_DIR_PATH = GENERATOR_PLAYGROUND_PATH.join("terraform")
 
 describe Command::Terraform::Generate do
+  subject(:result) { run_cpflow_command(described_class::SUBCOMMAND_NAME, described_class::NAME, "-a", app) }
+
   let!(:app) { dummy_test_app }
 
   before do
@@ -23,12 +25,58 @@ describe Command::Terraform::Generate do
 
   it "generates terraform config files", :aggregate_failures do
     config_file_paths.each { |config_file_path| expect(config_file_path).not_to exist }
-    run_cpflow_command(described_class::SUBCOMMAND_NAME, described_class::NAME, "-a", app)
+
+    expect(result[:status]).to eq(0)
+
     expect(config_file_paths).to all(exist)
   end
 
+  context "when templates folder is empty" do
+    let(:template_dir) { "non-existing-folder" }
+
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(TemplateParser).to receive(:template_dir).and_return(template_dir)
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    it "generates only common config files" do
+      config_file_paths.each { |config_file_path| expect(config_file_path).not_to exist }
+
+      expect(result[:stderr]).to include("No templates found in #{template_dir}")
+
+      expect(common_config_files).to all(exist)
+      app_config_files.each { |config_file_path| expect(config_file_path).not_to exist }
+    end
+  end
+
+  context "when template parsing fails" do
+    before do
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(TemplateParser).to receive(:parse).and_raise("error")
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    it "generates only common config files" do
+      config_file_paths.each { |config_file_path| expect(config_file_path).not_to exist }
+
+      expect(result[:stderr]).to include("Error parsing templates: error")
+
+      expect(common_config_files).to all(exist)
+      app_config_files.each { |config_file_path| expect(config_file_path).not_to exist }
+    end
+  end
+
   def config_file_paths
-    [TERRAFORM_CONFIG_DIR_PATH.join("providers.tf")] + %w[gvc.tf identities.tf].map do |config_file_path|
+    common_config_files + app_config_files
+  end
+
+  def common_config_files
+    [TERRAFORM_CONFIG_DIR_PATH.join("providers.tf")]
+  end
+
+  def app_config_files
+    %w[gvc.tf identities.tf].map do |config_file_path|
       TERRAFORM_CONFIG_DIR_PATH.join(app, config_file_path)
     end
   end

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -12,23 +12,24 @@ describe Command::Terraform::Generate do
   let!(:app) { dummy_test_app }
 
   before do
-    FileUtils.rm_r(GENERATOR_PLAYGROUND_PATH) if Dir.exist?(GENERATOR_PLAYGROUND_PATH)
-    FileUtils.mkdir_p GENERATOR_PLAYGROUND_PATH
-
+    FileUtils.rm_rf(GENERATOR_PLAYGROUND_PATH)
+    FileUtils.mkdir_p(GENERATOR_PLAYGROUND_PATH)
     allow(Cpflow).to receive(:root_path).and_return(GENERATOR_PLAYGROUND_PATH)
   end
 
   after do
-    FileUtils.rm_r GENERATOR_PLAYGROUND_PATH
+    FileUtils.rm_rf GENERATOR_PLAYGROUND_PATH
   end
 
   it "generates terraform config files", :aggregate_failures do
-    config_file_paths = %w[providers.tf gvc.tf identities.tf].map do |config_file_path|
-      TERRAFORM_CONFIG_DIR_PATH.join(config_file_path)
-    end
-
     config_file_paths.each { |config_file_path| expect(config_file_path).not_to exist }
     run_cpflow_command(described_class::SUBCOMMAND_NAME, described_class::NAME, "-a", app)
     expect(config_file_paths).to all(exist)
+  end
+
+  def config_file_paths
+    [TERRAFORM_CONFIG_DIR_PATH.join("providers.tf")] + %w[gvc.tf identities.tf].map do |config_file_path|
+      TERRAFORM_CONFIG_DIR_PATH.join(app, config_file_path)
+    end
   end
 end

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -9,6 +9,8 @@ GENERATOR_PLAYGROUND_PATH = GEM_TEMP_PATH.join("sample-project")
 TERRAFORM_CONFIG_DIR_PATH = GENERATOR_PLAYGROUND_PATH.join("terraform")
 
 describe Command::Terraform::Generate do
+  let!(:app) { dummy_test_app }
+
   before do
     FileUtils.rm_r(GENERATOR_PLAYGROUND_PATH) if Dir.exist?(GENERATOR_PLAYGROUND_PATH)
     FileUtils.mkdir_p GENERATOR_PLAYGROUND_PATH
@@ -20,11 +22,13 @@ describe Command::Terraform::Generate do
     FileUtils.rm_r GENERATOR_PLAYGROUND_PATH
   end
 
-  it "generates terraform config files" do
-    providers_config_file_path = TERRAFORM_CONFIG_DIR_PATH.join("providers.tf")
+  it "generates terraform config files", :aggregate_failures do
+    config_file_paths = %w[providers.tf gvc.tf identities.tf].map do |config_file_path|
+      TERRAFORM_CONFIG_DIR_PATH.join(config_file_path)
+    end
 
-    expect(providers_config_file_path).not_to exist
-    run_cpflow_command(described_class::SUBCOMMAND_NAME, described_class::NAME)
-    expect(providers_config_file_path).to exist
+    config_file_paths.each { |config_file_path| expect(config_file_path).not_to exist }
+    run_cpflow_command(described_class::SUBCOMMAND_NAME, described_class::NAME, "-a", app)
+    expect(config_file_paths).to all(exist)
   end
 end

--- a/spec/core/terraform_config/generator_spec.rb
+++ b/spec/core/terraform_config/generator_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TerraformConfig::Generator do
+  let(:generator) { described_class.new(config: config, template: template) }
+
+  let(:config) { instance_double(Config, org: "org-name", app: "app-name") }
+
+  context "when template's kind is gvc" do
+    let(:template) do
+      {
+        "kind" => "gvc",
+        "name" => config.app,
+        "description" => "description",
+        "tags" => { "tag1" => "tag1_value", "tag2" => "tag2_value" },
+        "spec" => {
+          "domain" => "app.example.com",
+          "env" => [
+            {
+              "name" => "DATABASE_URL",
+              "value" => "postgres://the_user:the_password@postgres.#{config.app}.cpln.local:5432/#{config.app}"
+            },
+            {
+              "name" => "RAILS_ENV",
+              "value" => "production"
+            },
+            {
+              "name" => "RAILS_SERVE_STATIC_FILES",
+              "value" => "true"
+            }
+          ],
+          "staticPlacement" => {
+            "locationLinks" => ["/org/#{config.org}/location/aws-us-east-2"]
+          },
+          "pullSecretLinks" => ["/org/#{config.org}/secret/some-secret"],
+          "loadBalancer" => {
+            "dedicated" => true,
+            "trustedProxies" => 1
+          }
+        }
+      }
+    end
+
+    it "generates correct terraform config and filename for it", :aggregate_failures do
+      tf_config = generator.tf_config
+      expect(tf_config).to be_an_instance_of(TerraformConfig::Gvc)
+
+      expect(tf_config.name).to eq(config.app)
+      expect(tf_config.description).to eq("description")
+      expect(tf_config.tags).to eq("tag1" => "tag1_value", "tag2" => "tag2_value")
+
+      expect(tf_config.domain).to eq("app.example.com")
+      expect(tf_config.locations).to eq(["aws-us-east-2"])
+      expect(tf_config.pull_secrets).to eq(["cpln_secret.some-secret.name"])
+      expect(tf_config.env).to eq(
+        {
+          "DATABASE_URL" => "postgres://the_user:the_password@postgres.#{config.app}.cpln.local:5432/#{config.app}",
+          "RAILS_ENV" => "production",
+          "RAILS_SERVE_STATIC_FILES" => "true"
+        }
+      )
+      expect(tf_config.load_balancer).to eq({ dedicated: true, trusted_proxies: 1 })
+
+      tf_filename = generator.filename
+      expect(tf_filename).to eq("gvc.tf")
+    end
+  end
+
+  context "when template's kind is identity" do
+    let(:template) do
+      {
+        "kind" => "identity",
+        "name" => "identity-name",
+        "description" => "description",
+        "tags" => { "tag1" => "tag1_value", "tag2" => "tag2_value" }
+      }
+    end
+
+    it "generates correct terraform config and filename for it", :aggregate_failures do
+      tf_config = generator.tf_config
+      expect(tf_config).to be_an_instance_of(TerraformConfig::Identity)
+
+      expect(tf_config.name).to eq("identity-name")
+      expect(tf_config.description).to eq("description")
+      expect(tf_config.tags).to eq("tag1" => "tag1_value", "tag2" => "tag2_value")
+
+      tf_filename = generator.filename
+      expect(tf_filename).to eq("identities.tf")
+    end
+  end
+end

--- a/spec/core/terraform_config/gvc_spec.rb
+++ b/spec/core/terraform_config/gvc_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TerraformConfig::Gvc do
+  let(:config) { described_class.new(**options) }
+
+  describe "#to_tf" do
+    subject(:generated) { config.to_tf }
+
+    context "with required and optional args" do
+      let(:options) do
+        {
+          name: "gvc-name",
+          description: "gvc description",
+          domain: "app.example.com",
+          env: { "var1" => "value", "var2" => 1 },
+          tags: { "tag1" => "tag_value", "tag2" => true },
+          locations: %w[aws-us-east-1 aws-us-east-2],
+          pull_secrets: ["cpln_secret.docker.name"],
+          load_balancer: { "dedicated" => true, "trusted_proxies" => 1 }
+        }
+      end
+
+      it "generates correct config" do
+        expect(generated).to eq(
+          <<~EXPECTED
+            resource "cpln_gvc" "gvc-name" {
+              name = "gvc-name"
+              description = "gvc description"
+              tags = {
+                tag1 = "tag_value"
+                tag2 = true
+              }
+              domain = "app.example.com"
+              locations = ["aws-us-east-1", "aws-us-east-2"]
+              pull_secrets = ["cpln_secret.docker.name"]
+              env = {
+                var1 = "value"
+                var2 = 1
+              }
+              load_balancer {
+                dedicated = true
+                trusted_proxies = 1
+              }
+            }
+          EXPECTED
+        )
+      end
+    end
+  end
+end

--- a/spec/core/terraform_config/identity_spec.rb
+++ b/spec/core/terraform_config/identity_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TerraformConfig::Identity do
+  let(:config) { described_class.new(**options) }
+
+  describe "#to_tf" do
+    subject(:generated) { config.to_tf }
+
+    let(:options) do
+      {
+        gvc: "cpln_gvc.some-gvc.name",
+        name: "identity-name",
+        description: "identity description",
+        tags: { "tag1" => "true", "tag2" => "false" }
+      }
+    end
+
+    it "generates correct config" do
+      expect(generated).to eq(
+        <<~EXPECTED
+          resource "cpln_identity" "identity-name" {
+            gvc = cpln_gvc.some-gvc.name
+            name = "identity-name"
+            description = "identity description"
+            tags = {
+              tag1 = "true"
+              tag2 = "false"
+            }
+          }
+        EXPECTED
+      )
+    end
+  end
+end


### PR DESCRIPTION
### What does this PR do?

1. This PR introduces `TerraformConfig::Generator` class which takes YAML template and transforms them to Terraform config (`.tf` format). For now, only 2 types of templates are supported - `gvc` and `identity`

Support for other template types will be added in later PRs

2. `cpflow terraform generate` command now accepts 2 optional arguments: application name and directory to save generated terraform config files to.

- If application name is not provided config files will be generated for each app defined in `controlplane.yml` in folder with app name
- Default directory where config files are saved is `./terraform`

3. Each time command `cpflow terraform generate` is invoked configuration files are recreated

### Terraform docs

https://registry.terraform.io/providers/controlplane-com/cpln/latest/docs/resources/gvc
https://registry.terraform.io/providers/controlplane-com/cpln/latest/docs/resources/identity

### Examples

YAML template for CPLN gvc:
```
kind: gvc
name: app-name
description: app-description
tags:
  tag-name-1: "tag-value-1"
  tag-name-2: "tag-value-2"
spec:
  domain: "app.example.com"
  env:
    - name: DATABASE_URL
      value: "postgres://the_user:the_password@postgres.app-name.cpln.local:5432/app-name"
    - name: RAILS_ENV
      value: production
    - name: RAILS_SERVE_STATIC_FILES
      value: "true"
  staticPlacement:
    locationLinks:
      - "//location/aws-us-west-2"
  pullSecretLinks:
    - "/org/org-name/secret/some-secret"
  loadBalancer:
    dedicated: true
    trustedProxies: 0
```

Will transform to:
```
resource "cpln_gvc" "app-name" {
  name = "app-name"
  description = "app-description"
  tags = {
    tag_name_1 = "tag-value-1"
    tag_name_2 = "tag-value-2"
  }
  domain = "app.example.com"
  locations = ["aws-us-west-2"]
  pull_secrets = ["cpln_secret.some-secret.name"]
  env = {
    DATABASE_URL = "postgres://the_user:the_password@postgres.app-name.cpln.local:5432/app-name"
    RAILS_ENV = "production"
    RAILS_SERVE_STATIC_FILES = "true"
  }
  load_balancer {
    dedicated = true
    trusted_proxies = 0
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation for the `cpflow terraform generate` command to include a new required argument, `$APP_NAME`.
	- Introduced new options for specifying output directories in command execution.
	- Added support for generating Terraform configuration files based on different templates, enhancing modularity and reusability.

- **Bug Fixes**
	- Improved robustness of file handling in test setups.

- **Tests**
	- Added comprehensive tests for the `TerraformConfig::Generator`, `Gvc`, and `Identity` classes to ensure correct configuration generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->