### PR TITLE
Support terraform config generation from agent template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@
 /spec/dummy/.controlplane/controlplane*-tmp-*.yml
 
 # Generated configs
-terraform/
-.controlplane/
+/terraform/
+/.controlplane/

--- a/lib/core/terraform_config/agent.rb
+++ b/lib/core/terraform_config/agent.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TerraformConfig
+  class Agent < Base
+    attr_reader :name, :description, :tags
+
+    def initialize(name:, description: nil, tags: nil)
+      super()
+
+      @name = name
+      @description = description
+      @tags = tags
+    end
+
+    def to_tf
+      block :resource, :cpln_agent, name do
+        argument :name, name
+        argument :description, description, optional: true
+        argument :tags, tags, optional: true
+      end
+    end
+  end
+end

--- a/lib/core/terraform_config/generator.rb
+++ b/lib/core/terraform_config/generator.rb
@@ -2,7 +2,7 @@
 
 module TerraformConfig
   class Generator # rubocop:disable Metrics/ClassLength
-    SUPPORTED_TEMPLATE_KINDS = %w[gvc secret identity policy volumeset workload].freeze
+    SUPPORTED_TEMPLATE_KINDS = %w[gvc secret identity policy volumeset workload agent].freeze
     WORKLOAD_SPEC_KEYS = %i[
       type
       containers
@@ -102,6 +102,10 @@ module TerraformConfig
       ].to_h { |key| [key, template.dig(:spec, key)] }
 
       template.slice(:name, :description, :tags).merge(gvc: gvc).merge(specs)
+    end
+
+    def agent_config_params
+      template.slice(:name, :description, :tags)
     end
 
     def workload_config_params

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -23,6 +23,7 @@ TEMPLATE_CONFIG_PATHS = %w[
   maintenance
   maintenance_envs
   maintenance-with-external-image
+  agents
 ].freeze
 
 describe Command::Terraform::Generate do

--- a/spec/core/terraform_config/agent_spec.rb
+++ b/spec/core/terraform_config/agent_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TerraformConfig::Agent do
+  let(:config) { described_class.new(**options) }
+
+  describe "#to_tf" do
+    subject(:generated) { config.to_tf }
+
+    let(:options) do
+      {
+        name: "agent-name",
+        description: "agent description",
+        tags: { "tag1" => "true", "tag2" => "value" }
+      }
+    end
+
+    it "generates correct config" do
+      expect(generated).to eq(
+        <<~EXPECTED
+          resource "cpln_agent" "agent-name" {
+            name = "agent-name"
+            description = "agent description"
+            tags = {
+              tag1 = "true"
+              tag2 = "value"
+            }
+          }
+        EXPECTED
+      )
+    end
+  end
+end

--- a/spec/core/terraform_config/generator_spec.rb
+++ b/spec/core/terraform_config/generator_spec.rb
@@ -531,4 +531,32 @@ describe TerraformConfig::Generator do
       expect(main_tf_config.job).to be_nil
     end
   end
+
+  context "when template's kind is agent" do
+    let(:template) do
+      {
+        "kind" => "agent",
+        "name" => "agent-name",
+        "description" => "agent description",
+        "tags" => { "tag1" => "tag1_value", "tag2" => "tag2_value" }
+      }
+    end
+
+    it "generates correct terraform config and filename for it", :aggregate_failures do
+      expected_filename = "agents.tf"
+
+      tf_configs = generator.tf_configs
+      expect(tf_configs.count).to eq(1)
+
+      filenames = tf_configs.keys
+      expect(filenames).to contain_exactly(expected_filename)
+
+      tf_config = tf_configs[expected_filename]
+      expect(tf_config).to be_an_instance_of(TerraformConfig::Agent)
+
+      expect(tf_config.name).to eq("agent-name")
+      expect(tf_config.description).to eq("agent description")
+      expect(tf_config.tags).to eq(tag1: "tag1_value", tag2: "tag2_value")
+    end
+  end
 end

--- a/spec/dummy/.controlplane/templates/agent.yml
+++ b/spec/dummy/.controlplane/templates/agent.yml
@@ -1,0 +1,5 @@
+kind: agent
+name: agent-name
+description: agent description
+tags:
+  tag1: value1


### PR DESCRIPTION
### What does this PR do?

This PR adds support for converting templates with `type: agent` to terraform config format

### Terraform docs

https://registry.terraform.io/providers/controlplane-com/cpln/latest/docs/resources/agent

### Examples

```
kind: agent
name: agent-name
description: agent description
tags:
  tag: value
```

Transforms to:
```
resource "cpln_agent" "agent-name" {
  name = "agent-name"
  description = "agent description"
  tags = {
    tag = value
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Agent` class for managing Terraform configurations, allowing users to define agents with attributes like name, description, and tags.
	- Expanded the `Generator` class to support a new template kind, "agent," enhancing configuration generation capabilities.
	- Added a new YAML configuration file for defining agents.

- **Tests**
	- Added tests for the new `Agent` class and its `to_tf` method.
	- Created test cases for the `Generator` class to ensure correct handling of "agent" templates. 

- **Chores**
	- Updated `.gitignore` to refine ignored directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->