### PR TITLE
Support terraform config generation from auditctx template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@
 /spec/dummy/.controlplane/controlplane*-tmp-*.yml
 
 # Generated configs
-terraform/
-.controlplane/
+/terraform/
+/.controlplane/

--- a/lib/core/terraform_config/audit_context.rb
+++ b/lib/core/terraform_config/audit_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module TerraformConfig
+  class AuditContext < Base
+    attr_reader :name, :description, :tags
+
+    def initialize(name:, description: nil, tags: nil)
+      super()
+
+      @name = name
+      @description = description
+      @tags = tags
+    end
+
+    def to_tf
+      block :resource, :cpln_audit_context, name do
+        argument :name, name
+        argument :description, description, optional: true
+        argument :tags, tags, optional: true
+      end
+    end
+  end
+end

--- a/lib/core/terraform_config/generator.rb
+++ b/lib/core/terraform_config/generator.rb
@@ -2,7 +2,7 @@
 
 module TerraformConfig
   class Generator # rubocop:disable Metrics/ClassLength
-    SUPPORTED_TEMPLATE_KINDS = %w[gvc secret identity policy volumeset workload].freeze
+    SUPPORTED_TEMPLATE_KINDS = %w[gvc secret identity policy volumeset workload auditctx].freeze
     WORKLOAD_SPEC_KEYS = %i[
       type
       containers
@@ -44,6 +44,8 @@ module TerraformConfig
         "gvc.tf"
       when "workload"
         "#{template[:name]}.tf"
+      when "auditctx"
+        "audit_contexts.tf"
       else
         "#{kind.pluralize}.tf"
       end
@@ -54,8 +56,11 @@ module TerraformConfig
     end
 
     def config_class
-      if kind == "volumeset"
+      case kind
+      when "volumeset"
         TerraformConfig::VolumeSet
+      when "auditctx"
+        TerraformConfig::AuditContext
       else
         TerraformConfig.const_get(kind.capitalize)
       end
@@ -102,6 +107,10 @@ module TerraformConfig
       ].to_h { |key| [key, template.dig(:spec, key)] }
 
       template.slice(:name, :description, :tags).merge(gvc: gvc).merge(specs)
+    end
+
+    def auditctx_config_params
+      template.slice(:name, :description, :tags)
     end
 
     def workload_config_params

--- a/spec/command/terraform/generate_spec.rb
+++ b/spec/command/terraform/generate_spec.rb
@@ -23,6 +23,7 @@ TEMPLATE_CONFIG_PATHS = %w[
   maintenance
   maintenance_envs
   maintenance-with-external-image
+  audit_contexts
 ].freeze
 
 describe Command::Terraform::Generate do

--- a/spec/core/terraform_config/audit_context_spec.rb
+++ b/spec/core/terraform_config/audit_context_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe TerraformConfig::AuditContext do
+  let(:config) { described_class.new(**options) }
+
+  describe "#to_tf" do
+    subject(:generated) { config.to_tf }
+
+    let(:options) do
+      {
+        name: "audit-context-name",
+        description: "audit context description",
+        tags: { "tag1" => "true", "tag2" => "value" }
+      }
+    end
+
+    it "generates correct config" do
+      expect(generated).to eq(
+        <<~EXPECTED
+          resource "cpln_audit_context" "audit-context-name" {
+            name = "audit-context-name"
+            description = "audit context description"
+            tags = {
+              tag1 = "true"
+              tag2 = "value"
+            }
+          }
+        EXPECTED
+      )
+    end
+  end
+end

--- a/spec/core/terraform_config/generator_spec.rb
+++ b/spec/core/terraform_config/generator_spec.rb
@@ -253,6 +253,34 @@ describe TerraformConfig::Generator do
     end
   end
 
+  context "when template's kind is auditctx" do
+    let(:template) do
+      {
+        "kind" => "auditctx",
+        "name" => "audit-context-name",
+        "description" => "audit context description",
+        "tags" => { "tag1" => "tag1_value", "tag2" => "tag2_value" }
+      }
+    end
+
+    it "generates correct terraform config and filename for it", :aggregate_failures do
+      expected_filename = "audit_contexts.tf"
+
+      tf_configs = generator.tf_configs
+      expect(tf_configs.count).to eq(1)
+
+      filenames = tf_configs.keys
+      expect(filenames).to contain_exactly(expected_filename)
+
+      tf_config = tf_configs[expected_filename]
+      expect(tf_config).to be_an_instance_of(TerraformConfig::AuditContext)
+
+      expect(tf_config.name).to eq("audit-context-name")
+      expect(tf_config.description).to eq("audit context description")
+      expect(tf_config.tags).to eq(tag1: "tag1_value", tag2: "tag2_value")
+    end
+  end
+
   context "when template's kind is workload" do
     let(:template) do
       {

--- a/spec/dummy/.controlplane/templates/audit_context.yml
+++ b/spec/dummy/.controlplane/templates/audit_context.yml
@@ -1,0 +1,5 @@
+kind: auditctx
+name: audit-context-name
+description: audit context description
+tags:
+  tag1: value1


### PR DESCRIPTION
### What does this PR do?

This PR adds support for converting templates with `type: auditctx` to terraform config format

### Terraform docs

https://registry.terraform.io/providers/controlplane-com/cpln/latest/docs/resources/audit_context

### Examples

```
kind: auditctx
name: audit-context-name
description: audit context description
tags:
  tag: value
```

Transforms to:
```
resource "cpln_audit_context" "audit-context-name" {
  name = "audit-context-name"
  description = "audit context description"
  tags = {
    tag = value
  }
}
```