### PR TITLE
Remove test case dependent on `terraform` CLI

### DIFF
--- a/spec/command/terraform/import_spec.rb
+++ b/spec/command/terraform/import_spec.rb
@@ -139,22 +139,6 @@ describe Command::Terraform::Import do
       end
     end
 
-    context "with special characters in resource address and resource id" do
-      let(:resource_address) { "cpln_gvc.test-app;rm -rf /" }
-      let(:resource_id) { "test-app;rm -rf /" }
-
-      it "is protected from shell injection" do
-        terraform_import
-
-        expect(Shell).to have_received(:cmd).with(
-          "terraform", "import", resource_address, "test-app;rm -rf /",
-          capture_stderr: true
-        )
-
-        expect(Shell).to have_received(:info).with(/Invalid character/)
-      end
-    end
-
     def stub_terraform_import_with(success, output)
       allow(Shell).to receive(:cmd)
         .with("terraform", "import", resource_address, resource_id, capture_stderr: true)


### PR DESCRIPTION
### What does this PR do?

**Problem**

Test case that checks that `cpflow terraform import` command is protected from shell injection depends on existence of `terraform` CLI tool - we shouldn't be dependent on it

**Solution**

Removal of the test case

### Note

We know that `Shell.cmd` calls `Open.capture2e/capture2` and passes an array as args - which is safe from shell injection. And `Command::Terraform::Import#run_terraform_import` calls `Shell.cmd` the same way (string interpolation isn't used) - which means everything is safe