### PR TITLE
Add docker-context option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,14 @@ _Please add entries here for your pull requests that have not yet been released.
 ### Fixed
 
 - Fixed issue where `run` command fails when runner workload has ENV but original workload does not. [PR 227](https://github.com/shakacode/control-plane-flow/pull/227) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
-
 - Fixed potential infinite loop that could occur for a command if one of the execution steps fails and gets stuck. [PR 217](https://github.com/shakacode/control-plane-flow/pull/217) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
-
 - Fixed issue where app cannot be deleted because one of the workloads has a volumeset in-use. [PR 245](https://github.com/shakacode/control-plane-flow/pull/245) by [Zakir Dzhamaliddinov](https://github.com/zzaakiirr).
+- Fixed `resolv` may be not properly required [PR 250](https://github.com/shakacode/control-plane-flow/pull/250) by [Sergey Tarasov](https://github.com/dzirtusss).
+
+### Added
+
+- Added `--docker-context` option to `build-image` command. [PR 250](https://github.com/shakacode/control-plane-flow/pull/250) by [Sergey Tarasov](https://github.com/dzirtusss).
+
 
 ## [4.0.0] - 2024-08-21
 

--- a/lib/command/base.rb
+++ b/lib/command/base.rb
@@ -442,6 +442,17 @@ module Command
         }
       }
     end
+
+    def self.docker_context_option
+      {
+        name: :docker_context,
+        params: {
+          desc: "Path to the docker build context directory",
+          type: :string,
+          required: false
+        }
+      }
+    end
     # rubocop:enable Metrics/MethodLength
 
     def self.all_options

--- a/lib/command/build_image.rb
+++ b/lib/command/build_image.rb
@@ -5,7 +5,8 @@ module Command
     NAME = "build-image"
     OPTIONS = [
       app_option(required: true),
-      commit_option
+      commit_option,
+      docker_context_option
     ].freeze
     ACCEPTS_EXTRA_OPTIONS = true
     DESCRIPTION = "Builds and pushes the image to Control Plane"
@@ -34,9 +35,12 @@ module Command
       build_args = []
       build_args.push("GIT_COMMIT=#{commit}") if commit
 
+      docker_context = config.options[:docker_context] || config.app_dir
+
       cp.image_build(image_url, dockerfile: dockerfile,
                                 docker_args: config.args,
-                                build_args: build_args)
+                                build_args: build_args,
+                                docker_context: docker_context)
 
       push_path = "/org/#{config.org}/image/#{image_name}"
 

--- a/lib/command/deploy_image.rb
+++ b/lib/command/deploy_image.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "resolv"
+
 module Command
   class DeployImage < Base
     NAME = "deploy-image"

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -90,7 +90,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     api.query_images(org: a_org, gvc: a_gvc, gvc_op_type: gvc_op)
   end
 
-  def image_build(image, dockerfile:, docker_args: [], build_args: [])
+  def image_build(image, dockerfile:, docker_context:, docker_args: [], build_args: [])
     # https://docs.controlplane.com/guides/push-image#step-2
     # Might need to use `docker buildx build` if compatiblitity issues arise
     cmd = "docker build --platform=linux/amd64 -t #{image} -f #{dockerfile}"
@@ -98,7 +98,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
 
     cmd += " #{docker_args.join(' ')}" if docker_args.any?
     build_args.each { |build_arg| cmd += " --build-arg #{build_arg}" }
-    cmd += " #{config.app_dir}"
+    cmd += " #{docker_context}"
 
     perform!(cmd)
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new option for specifying the Docker context in the command interface.
	- Enhanced the `BuildImage` command to accept a custom Docker context.
	- Added the `--docker-context` option to the `build-image` command.

- **Bug Fixes**
	- Resolved an issue causing the `run` command to fail with mismatched environment variables.
	- Fixed a potential infinite loop during command execution if a step fails.
	- Addressed an issue preventing app deletion due to an in-use volumeset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->