### PR TITLE
Fix issue that happens when trying to fetch replicas with CPLN CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Changes since the last non-beta release.
 
 _Please add entries here for your pull requests that have not yet been released._
 
+### Fixed
+
+- Fixed issue where `ps`, `ps:start`, `ps:stop`, `ps:wait`, and `run` commands fail when trying to fetch replicas with CPLN CLI. [PR 254](https://github.com/shakacode/control-plane-flow/pull/254) by [Rafael Gomes](https://github.com/rafaelgomesxyz).
+
 ## [4.1.0] - 2024-12-17
 
 ### Fixed

--- a/lib/command/ps.rb
+++ b/lib/command/ps.rb
@@ -34,7 +34,7 @@ module Command
         cp.fetch_workload!(workload)
 
         result = cp.fetch_workload_replicas(workload, location: location)
-        result["items"].each { |replica| puts replica }
+        result&.dig("items")&.each { |replica| puts replica }
       end
     end
   end

--- a/lib/command/ps_stop.rb
+++ b/lib/command/ps_stop.rb
@@ -75,7 +75,8 @@ module Command
 
       step("Waiting for replica '#{replica}' to not be ready", retry_on_failure: true) do
         result = cp.fetch_workload_replicas(workload, location: config.location)
-        !result["items"].include?(replica)
+        items = result&.dig("items")
+        items && !items.include?(replica)
       end
     end
   end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -274,7 +274,7 @@ module Command
     def wait_for_replica_for_job
       step("Waiting for replica to start, which runs job '#{job}'", retry_on_failure: true) do
         result = cp.fetch_workload_replicas(runner_workload, location: location)
-        @replica = result["items"].find { |item| item.include?(job) }
+        @replica = result&.dig("items")&.find { |item| item.include?(job) }
 
         replica || false
       end

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -192,7 +192,7 @@ class Controlplane # rubocop:disable Metrics/ClassLength
   end
 
   def fetch_workload_replicas(workload, location:)
-    cmd = "cpln workload replica get #{workload} #{gvc_org} --location #{location} -o yaml"
+    cmd = "cpln workload replica get #{workload} #{gvc_org} --location #{location} -o yaml 2> /dev/null"
     perform_yaml(cmd)
   end
 
@@ -213,8 +213,8 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def workload_deployments_ready?(workload, location:, expected_status:)
-    deployed_replicas = fetch_workload_replicas(workload, location: location)["items"].length
+  def workload_deployments_ready?(workload, location:, expected_status:) # rubocop:disable Metrics/CyclomaticComplexity
+    deployed_replicas = fetch_workload_replicas(workload, location: location)&.dig("items")&.length || 0
     return deployed_replicas.zero? if expected_status == false
 
     deployments = fetch_workload_deployments(workload)["items"]


### PR DESCRIPTION
The CPLN CLI is currently raising an error when no replicas are found.

That causes the commands `ps`, `ps:start`, `ps:stop`, `ps:wait`, and `run` to fail when trying to fetch replicas.

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to document a fix addressing unstable behavior in replica-related commands.
- **Bug Fixes**
  - Improved error handling to prevent failures during replica data retrieval.
  - Enhanced command stability by suppressing extraneous error messages for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->