### PR TITLE
Add node_no_warnings environment variable

### DIFF
--- a/lib/cpflow.rb
+++ b/lib/cpflow.rb
@@ -51,6 +51,7 @@ module Cpflow
 
     def self.start(*args)
       ENV["CPLN_SKIP_UPDATE_CHECK"] = "true"
+      # ENV["NODE_NO_WARNINGS"] = "1"
 
       check_cpln_version
       check_cpflow_version


### PR DESCRIPTION
While figuring out how to test this locally, I also encountered [a really old error with the debug gem that should have been resolved a long time ago](https://github.com/ruby/debug/issues/275) (I'm using Ruby 2.7.3).