### PR TITLE
docs: trimmed post_install_message in cpflow.gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 ### Changed
 
 - **Simplified generated review-app help comments to a three-command quick reference, moved setup behind expandable details, and clarified GitHub Actions secret and variable terminology.** [PR 410](https://github.com/shakacode/control-plane-flow/pull/410) by [Justin Gordon](https://github.com/justin808).
+- **Update post-install message to reference updated action guidance and clean up stale specs.** [PR 419](https://github.com/shakacode/control-plane-flow/pull/419) by [rndbn](https://github.com/PandaBean18).
 
 ## [5.2.0] - 2026-07-10
 

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.post_install_message = <<~MESSAGE
     cpflow #{Cpflow::VERSION} installed.
 
-    If this repo uses generated cpflow GitHub Actions, run cpflow update-github-actions after upgrading.
+    If this repo uses generated cpflow GitHub Actions, run cpflow update-github-actions (or bundle exec cpflow update-github-actions) after upgrading.
 
     Docs: https://shakacode.com/control-plane-flow/docs/
   MESSAGE

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -15,19 +15,9 @@ Gem::Specification.new do |spec|
   spec.post_install_message = <<~MESSAGE
     cpflow #{Cpflow::VERSION} installed.
 
-    If this repository already uses generated cpflow GitHub Actions, update the
-    checked-in wrappers so GitHub loads the matching control-plane-flow release tag:
+    If this repo uses generated cpflow GitHub Actions, run cpflow update-github-actions after upgrading.
 
-      cpflow update-github-actions
-      bin/test-cpflow-github-flow
-
-    If you run cpflow through Bundler:
-
-      bundle exec cpflow update-github-actions
-      bin/test-cpflow-github-flow bundle exec cpflow
-
-    New repository? Run `cpflow generate-github-actions` first to create the
-    wrappers (and the `bin/test-cpflow-github-flow` script referenced above).
+    Docs: https://shakacode.com/control-plane-flow/docs/
   MESSAGE
 
   spec.required_ruby_version = ">= 3.0.0"

--- a/cpflow.gemspec
+++ b/cpflow.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
     If this repo uses generated cpflow GitHub Actions, run cpflow update-github-actions (or bundle exec cpflow update-github-actions) after upgrading.
 
-    Docs: https://shakacode.com/control-plane-flow/docs/
+    Docs: https://shakacode.com/control-plane-flow/docs/ci-automation/#updating-generated-github-actions-after-gem-updates
   MESSAGE
 
   spec.required_ruby_version = ">= 3.0.0"

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -136,6 +136,6 @@ describe Cpflow do
     spec = Gem::Specification.load(File.expand_path("../cpflow.gemspec", __dir__))
 
     expect(spec.post_install_message).to include("cpflow update-github-actions")
-    expect(spec.post_install_message).to include("https://shakacode.com/control-plane-flow/docs/")
+    expect(spec.post_install_message).to include("https://shakacode.com/control-plane-flow/docs/ci-automation/#updating-generated-github-actions-after-gem-updates")
   end
 end

--- a/spec/cpflow_spec.rb
+++ b/spec/cpflow_spec.rb
@@ -136,6 +136,6 @@ describe Cpflow do
     spec = Gem::Specification.load(File.expand_path("../cpflow.gemspec", __dir__))
 
     expect(spec.post_install_message).to include("cpflow update-github-actions")
-    expect(spec.post_install_message).to include("bin/test-cpflow-github-flow")
+    expect(spec.post_install_message).to include("https://shakacode.com/control-plane-flow/docs/")
   end
 end


### PR DESCRIPTION
Fixes #377

### Summary
Trims the 17-line `post_install_message` in `cpflow.gemspec` down to a concise notification pointing to the official documentation.

### Changes
- Condensed the installation message in `cpflow.gemspec` to keep terminal output clean upon gem install/upgrade.
- Preserved the note for users with generated GitHub Actions workflows (`cpflow update-github-actions`).
- Added a link to the official documentation portal: `https://shakacode.com/control-plane-flow/docs/`.

### Verification
- Ran `gem build cpflow.gemspec` to verify the gemspec builds cleanly without syntax errors.
- Ran `bundle exec rubocop cpflow.gemspec` with 0 offenses detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the post-install guidance to direct users to run `cpflow update-github-actions` after upgrading when generated GitHub Actions are used.
  * Added a documentation link with instructions for updating generated workflows.
  * Removed outdated guidance and cleaned up stale specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->