### PR TITLE
Configure direct merge submission

### DIFF
--- a/.agents/agent-workflow.yml
+++ b/.agents/agent-workflow.yml
@@ -3,6 +3,8 @@
 # AGENTS.md directs portable skills here; it does not duplicate or override them.
 # Commands live as scripts in .agents/bin/ (see .agents/bin/README.md).
 base_branch: main
+merge_submission:
+  mode: direct
 changelog: "CHANGELOG.md — Keep-a-Changelog; user-visible changes only"
 follow_up_prefix: "Follow-up:"
 review_gate: "AI reviewers are advisory unless they confirm a blocker; merge gate is the full `gh pr checks` list green (not --required) + all threads resolved + mergeable clean"


### PR DESCRIPTION
## Summary
- explicitly configure the agent-workflow merge submission mode as `direct`
- leave GitHub repository and Merge Queue settings unchanged

## Validation
- Ruby YAML parse and `merge_submission.mode == direct` assertion
- agent-workflow seam doctor against `shakacode/agent-workflows` main at `845ab026`
- `git diff --check`

Source dependency: shakacode/agent-workflows#407 (merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured submissions to use direct merge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->