### PR TITLE
Document scale-to-zero landing-page handoff

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -621,7 +621,7 @@ migration and can interrupt traffic.
 
 For a public demo, review app, or staging app where the first request's cold start would be a poor first impression,
 serve a lightweight landing page independently of the app that scales to zero. Route visitors to that landing page
-first, then have its **Open app** action request the separate serverless app. The page can immediately explain that the
+first, then have a button on that page request the separate serverless app. The page can immediately explain that the
 app is starting while the serverless workload wakes; it does not remove the cold start, but it keeps that wait out of
 the initial page render.
 
@@ -632,8 +632,7 @@ always-available landing page -> Open app request -> serverless app (minScale: 0
 The landing page, its hosting, and any DNS, proxy, rewrite, or redirect rules are application infrastructure you
 choose and operate. `cpflow` does not create that routing infrastructure. Keep the app as a separate serverless
 workload from its first deployment (or perform the planned delete/recreate migration above); it cannot convert an
-existing standard workload in place. The wake-up path also requires the HTTP autoscaling configuration shown above and
-will not work while `cpflow ps:stop` has suspended the app.
+existing standard workload in place. The wake-up path also requires the HTTP autoscaling configuration shown above.
 
 > **Note:** if you later suspend the app with `cpflow ps:stop`, Control Plane will not auto-wake it on the next
 > request. Run `cpflow ps:start` explicitly first. See

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -18,6 +18,7 @@
 13. [Minimizing Non-Production App Costs](#minimizing-non-production-app-costs)
     - [Share One Control Plane Postgres for Staging and Review Apps](#share-one-control-plane-postgres-for-staging-and-review-apps)
     - [Enable Capacity AI for Demo and Starter Staging Apps](#enable-capacity-ai-for-demo-and-starter-staging-apps)
+    - [Use an Always-Available Landing Page for a Serverless App](#use-an-always-available-landing-page-for-a-serverless-app)
     - [Delete or Pause Abandoned Apps with `cleanup-stale-apps`](#delete-or-pause-abandoned-apps-with-cleanup-stale-apps)
     - [Pause and Resume with `ps:stop` / `ps:start`](#pause-and-resume-with-psstop--psstart)
 14. [Right-Sizing Non-Production Workloads](#right-sizing-non-production-workloads)
@@ -615,6 +616,24 @@ migration and can interrupt traffic.
 
 > **Warning:** Treat a `standard` to `serverless` conversion as an operational migration because deleting a running
 > workload can interrupt traffic.
+
+### Use an Always-Available Landing Page for a Serverless App
+
+For a public demo, review app, or staging app where the first request's cold start would be a poor first impression,
+serve a lightweight landing page independently of the app that scales to zero. Route visitors to that landing page
+first, then have its **Open app** action request the separate serverless app. The page can immediately explain that the
+app is starting while the serverless workload wakes; it does not remove the cold start, but it keeps that wait out of
+the initial page render.
+
+```text
+always-available landing page -> Open app request -> serverless app (minScale: 0) -> cold start -> app response
+```
+
+The landing page, its hosting, and any DNS, proxy, rewrite, or redirect rules are application infrastructure you
+choose and operate. `cpflow` does not create that routing infrastructure. Keep the app as a separate serverless
+workload from its first deployment (or perform the planned delete/recreate migration above); it cannot convert an
+existing standard workload in place. The wake-up path also requires the HTTP autoscaling configuration shown above and
+will not work while `cpflow ps:stop` has suspended the app.
 
 > **Note:** if you later suspend the app with `cpflow ps:stop`, Control Plane will not auto-wake it on the next
 > request. Run `cpflow ps:start` explicitly first. See


### PR DESCRIPTION
## Summary

Document an application-owned landing-page handoff for serverless apps that scale to zero. The new guidance explains the cold-start experience, routing boundary, standard-to-serverless migration constraint, and `ps:stop` limitation.

## Related issue

Closes #391.

## Validation

- `./script/check_cpln_links docs/tips.md`
- `git diff --check origin/main...HEAD`
- Manual review against the current serverless and scale-to-zero guidance

## Checklist

- [x] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
- [x] The change is focused and contains no unrelated cleanup or generated churn.
- [x] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
- [x] I reviewed and understand all submitted content, including AI-assisted changes.

<details>
<summary>Agent details</summary>

### Exact-head evidence

- Base: `d162df2543aeb6cc2e7502bf996877bf6d8a5080`
- Head: `357df2dc132147895581b69f2faf378dc4fa4d89`
- Reviewed diff: 19 insertions in `docs/tips.md`
- Second-model review: not required for this focused documentation-only lane; link, anchor, and exact-diff review completed

### QA Evidence

- Required: no
- Status: complete
- Head: `357df2dc132147895581b69f2faf378dc4fa4d89`
- Tested at: `357df2dc132147895581b69f2faf378dc4fa4d89`
- Automated: documentation link and diff checks passed
- Manual: not applicable beyond documentation accuracy review
- UI changed: no
- Visuals/interactions/performance: not applicable
- Findings: two optional inline documentation nits fixed; two later clarity suggestions reviewed and declined at the final-candidate debounce because the current wording is understandable and behavior-neutral
- Release QA: not_applicable
- Process gap: not applicable

<!-- qa-evidence v2 required:no status:complete head:357df2dc132147895581b69f2faf378dc4fa4d89 tested_at:357df2dc132147895581b69f2faf378dc4fa4d89 -->
<!-- priority-finding-dispositions v1 status:complete optional:fixed -->

### Coordination

- Batch: `cpf-20260831-1850-throughput`
- Lane: issue #391 / `jg-codex/391-scale-to-zero-docs`
- Merge authority: explicit maintainer approval required

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using an always-available landing page with serverless applications that scale to zero.
  * Added the new guidance to the documentation table of contents.
  * Clarified infrastructure requirements and limitations when applying this approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->