### PR TITLE
Verify Cloud Wormhole networkResources casing

### DIFF
--- a/docs/rds-private-networking.md
+++ b/docs/rds-private-networking.md
@@ -6,9 +6,8 @@ path — not the public internet.
 
 This guide covers the recommended setup: **CPLN Cloud Wormhole via an Agent**.
 
-> **Field casing verified.** In September 2026, sanitized `cpln identity get <name> -o yaml-slim`
-> exports from 29 identities and 227 network resources across four accessible live orgs confirmed the
-> `networkResources` nesting and the common `name`, `agentLink`, `FQDN`, and `ports` field casing.
+> **Field casing verified.** Sanitized `cpln identity get <name> -o yaml-slim` exports from live orgs
+> confirmed the `networkResources` nesting and the common `name`, `agentLink`, `FQDN`, and `ports` field casing.
 > The current Control Plane [Identity reference](https://shakadocs.controlplane.com/reference/identity) and
 > [Identity API](https://shakadocs.controlplane.com/api-reference/identity/get-an-identity-by-gvc-and-name)
 > confirm the optional `IPs` and `resolverIP` spellings; none of the inspected live resources used those
@@ -235,10 +234,9 @@ cpln identity get my-app-production-identity \
 Edit `identity-db.yaml` and **add** the `networkResources` block — keep every other apply-safe field
 exactly as exported:
 
-> **Field casing:** live `yaml-slim` exports confirm `networkResources`, `name`, `agentLink`, `FQDN`,
-> and `ports`. The current Control Plane identity reference and API schema confirm the optional `IPs`
-> and `resolverIP` fields. Diff your edited file against the original export before applying so a typo
-> or future schema change cannot silently remove the intended route.
+> **Apply-safe editing:** start from a fresh `yaml-slim` export and diff your edited file against the
+> original before applying. This prevents a typo or future schema change from silently removing the
+> intended route. The verified casing sources are summarized at the top of this guide.
 
 ```yaml
 # identity-db.yaml (after edit — abbreviated, your file will have more fields)
@@ -322,9 +320,9 @@ policy name if you've overridden `secrets_policy_name` in `controlplane.yml`.
 > by a `my-app` entry has identity `my-app-production-identity` but secret `my-app-secrets` and policy
 > `my-app-secrets-policy`. Confirm yours with `cpln secret get --gvc <app> --org <org>` if unsure.
 
-Live verification inspected only field names and nesting; endpoint, resolver, and agent values were not
-recorded. All 227 inspected resources used the FQDN form. The optional IP form below is therefore verified
-against the current Control Plane reference and API schema rather than an observed live identity.
+> **Verification scope.** Live inspection covered field names and nesting only; endpoint, resolver, and
+> agent values were not recorded. The optional IP form below follows the current Control Plane reference
+> and API schema rather than an observed live identity.
 
 Schema notes (per CPLN's documented `networkResources` schema):
 

--- a/docs/rds-private-networking.md
+++ b/docs/rds-private-networking.md
@@ -6,13 +6,14 @@ path — not the public internet.
 
 This guide covers the recommended setup: **CPLN Cloud Wormhole via an Agent**.
 
-> **Sourcing note — verify field casing before you apply.** Field names, schema, and limits in this guide
-> are sourced from the public Control Plane documentation at <https://shakadocs.controlplane.com> as of
-> May 2026 and have **not** been end-to-end verified against a live org. This matters because a casing
-> mismatch **fails silently**: `cpln apply` accepts the file, ignores the unrecognized field, and the
-> workload then can't reach the database — with no error pointing back to the YAML. Before applying in
-> production, diff your edited files against a fresh `cpln identity get <name> -o yaml-slim` (and
-> `cpln agent get <name> -o yaml`) export to confirm the exact field names, and consult
+> **Field casing verified.** In September 2026, sanitized `cpln identity get <name> -o yaml-slim`
+> exports from 29 identities and 227 network resources across four accessible live orgs confirmed the
+> `networkResources` nesting and the common `name`, `agentLink`, `FQDN`, and `ports` field casing.
+> The current Control Plane [Identity reference](https://shakadocs.controlplane.com/reference/identity) and
+> [Identity API](https://shakadocs.controlplane.com/api-reference/identity/get-an-identity-by-gvc-and-name)
+> confirm the optional `IPs` and `resolverIP` spellings; none of the inspected live resources used those
+> optional fields. Before applying in production, still diff your edited file against a fresh identity
+> export and consult
 > `cpln <command> --help` for the latest CLI flags.
 
 ## Why private networking
@@ -234,11 +235,10 @@ cpln identity get my-app-production-identity \
 Edit `identity-db.yaml` and **add** the `networkResources` block — keep every other apply-safe field
 exactly as exported:
 
-> ⚠️ **Verify field casing against your org before applying.** The field names below (`FQDN`, `IPs`,
-> `agentLink`, `resolverIP`) are sourced from public CPLN docs. If the live API uses different casing,
-> `cpln apply` will accept the file but silently ignore the resource — workloads will hit
-> `could not translate host name` with no obvious link to the identity YAML. Diff your edited file
-> against the original `yaml-slim` export from `cpln identity get` to confirm.
+> **Field casing:** live `yaml-slim` exports confirm `networkResources`, `name`, `agentLink`, `FQDN`,
+> and `ports`. The current Control Plane identity reference and API schema confirm the optional `IPs`
+> and `resolverIP` fields. Diff your edited file against the original export before applying so a typo
+> or future schema change cannot silently remove the intended route.
 
 ```yaml
 # identity-db.yaml (after edit — abbreviated, your file will have more fields)
@@ -321,6 +321,10 @@ policy name if you've overridden `secrets_policy_name` in `controlplane.yml`.
 > **shorter than the full app name** used for the GVC and identity — e.g. an app `my-app-production` matched
 > by a `my-app` entry has identity `my-app-production-identity` but secret `my-app-secrets` and policy
 > `my-app-secrets-policy`. Confirm yours with `cpln secret get --gvc <app> --org <org>` if unsure.
+
+Live verification inspected only field names and nesting; endpoint, resolver, and agent values were not
+recorded. All 227 inspected resources used the FQDN form. The optional IP form below is therefore verified
+against the current Control Plane reference and API schema rather than an observed live identity.
 
 Schema notes (per CPLN's documented `networkResources` schema):
 

--- a/docs/rds-private-networking.md
+++ b/docs/rds-private-networking.md
@@ -10,9 +10,10 @@ This guide covers the recommended setup: **CPLN Cloud Wormhole via an Agent**.
 > confirmed the `networkResources` nesting and the common `name`, `agentLink`, `FQDN`, and `ports` field casing.
 > The current Control Plane [Identity reference](https://shakadocs.controlplane.com/reference/identity) and
 > [Identity API](https://shakadocs.controlplane.com/api-reference/identity/get-an-identity-by-gvc-and-name)
-> confirm the optional `IPs` and `resolverIP` spellings; none of the inspected live resources used those
-> optional fields. Before applying in production, still diff your edited file against a fresh identity
-> export and consult
+> confirm the alternative `IPs` form and optional `resolverIP` spelling; neither appeared in the inspected
+> live resources. Field names are case-sensitive: `cpln apply` can accept an unrecognized field while omitting
+> the intended route, without pointing back to the identity YAML. Before applying in production, check the new
+> block against these casing sources, diff your edited file against a fresh identity export, and consult
 > `cpln <command> --help` for the latest CLI flags.
 
 ## Why private networking
@@ -235,8 +236,9 @@ Edit `identity-db.yaml` and **add** the `networkResources` block — keep every 
 exactly as exported:
 
 > **Apply-safe editing:** start from a fresh `yaml-slim` export and diff your edited file against the
-> original before applying. This prevents a typo or future schema change from silently removing the
-> intended route. The verified casing sources are summarized at the top of this guide.
+> original before applying. This helps detect unintended changes to exported fields, but it does not validate
+> the newly added `networkResources` block. Check every key in that block, including `agentLink`, `FQDN`/`IPs`,
+> `resolverIP`, and `ports`, against the verified casing sources above.
 
 ```yaml
 # identity-db.yaml (after edit — abbreviated, your file will have more fields)
@@ -319,10 +321,6 @@ policy name if you've overridden `secrets_policy_name` in `controlplane.yml`.
 > **shorter than the full app name** used for the GVC and identity — e.g. an app `my-app-production` matched
 > by a `my-app` entry has identity `my-app-production-identity` but secret `my-app-secrets` and policy
 > `my-app-secrets-policy`. Confirm yours with `cpln secret get --gvc <app> --org <org>` if unsure.
-
-> **Verification scope.** Live inspection covered field names and nesting only; endpoint, resolver, and
-> agent values were not recorded. The optional IP form below follows the current Control Plane reference
-> and API schema rather than an observed live identity.
 
 Schema notes (per CPLN's documented `networkResources` schema):
 


### PR DESCRIPTION
## Summary

- replace the original unverified-sourcing caveat with sanitized live Control Plane evidence
- document the exact `networkResources` nesting and casing observed in read-only exports
- distinguish the common live-observed FQDN form from the alternative `IPs` form and optional `resolverIP` field verified in the current first-party schema
- keep point-in-time inventory counts in this PR as audit provenance rather than permanent guide content
- retain the safety instruction to diff an edited identity against a fresh export before applying it

## Live verification

Read-only `cpln` queries inspected every accessible org without printing or retaining endpoint, resolver, agent, identity, credential, or secret values. At verification time, four orgs contained 29 identities with 227 network resources. Every observed resource used exactly `name`, `agentLink`, `FQDN`, and `ports` beneath the top-level `networkResources` field. None used the optional IP form, so the guide states transparently that `IPs` and `resolverIP` are schema-verified rather than live-observed.

## Related issue

Closes #332

## Validation

- `./script/check_cpln_links docs/rds-private-networking.md` — passed
- `./script/check_command_docs` — passed
- `git diff --check origin/main...HEAD` — passed
- focused content checks — passed; no point-in-time inventory counts remain in the guide, and the three remaining callouts have distinct purposes
- `codex review --base origin/main` — clean; no actionable defect in the exact committed diff
- `.agents/bin/validate` — attempted on the preceding docs-only head; RSpec stopped before RuboCop because this host has no `CPLN_ORG` provisioning (`857 examples, 181 failures`, seed `15267`, with command specs reporting `No org provided` and exit 64). The final content instead has current focused checks and independent review; hosted checks must pass on the exact published head.

No changelog entry is included because this closes a documentation-verification task without changing gem behavior.

## Checklist

- [x] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
- [x] The change is focused and contains no unrelated cleanup or generated churn.
- [x] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
- [x] I reviewed and understand all submitted content, including AI-assisted changes.

<details>
<summary>Agent details</summary>

### Exact-head evidence

- Current `main` during local validation: `bc75f8b281e92e2cd9ec2c983c5f01a672e1e34d`
- Branch merge base: `4d3f6b5642b05b0feb4b1643fa8b1ab212938be0`
- Head: `370002b8ec1c21fa984926773cc014227a93b41d`
- Changed path: `docs/rds-private-networking.md` only
- Independent review: clean at the committed diff; no accepted or actionable finding

### Review dispositions

- Claude's point-in-time-count and duplicated-casing finding is addressed: permanent guide counts were removed and the durable casing result now appears once.
- Claude's callout-format finding is addressed: verification scope is a blockquote and no longer repeats the casing claim.
- Claude's current-head accuracy finding is addressed: `IPs` is now the alternative to `FQDN`, only `resolverIP` is called optional, and the silent casing-failure mechanism is retained.
- Claude's current-head duplication finding is addressed: the redundant lower verification-scope callout was removed.
- CodeRabbit's current-head apply-safety finding is addressed: export diffing is limited to unintended changes in exported fields, and the guide requires checking every new `networkResources` key against the verified casing sources.
- The Claude and CodeRabbit review summaries duplicate their inline findings and require no separate content change.
- Claude's sourcing-authorization process note is satisfied by the maintainer-authorized read-only verification recorded here; it did not require another content change.

### QA Evidence

- QA lane: `cpf-post413-pr448-root`, `/Users/justin/.codex/worktrees/cpf-wave2-issue332/control-plane-flow`, private claims for PR #448 and issue #332 active
- Scope checked: live identity YAML nesting and field casing, documentation claims, optional-field schema, link validity, command-doc drift, diff hygiene, and both current review findings
- Tested at: `370002b8ec1c21fa984926773cc014227a93b41d`
- Automated checks: repository Control Plane link check, command-doc check, diff check, focused content assertions, and independent Codex review passed
- Manual checks: durable sanitized read-only evidence records 29 identities and 227 resources across four accessible orgs; no live values or secrets were retained. The current edit removes those point-in-time counts from the permanent guide.
- User-visible UI change: no
- Visual evidence: not applicable; no user-visible UI changed
- Interaction change: no; documentation only
- Interaction evidence: not applicable; no interaction changed
- Visual fix: no
- Negative control: not applicable; no visual fix
- Performance evidence: not applicable; no performance-sensitive path changed
- Findings: none
- QA required: yes
- QA required rationale: the issue explicitly required live Control Plane evidence before narrowing the caveat
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 370002b8ec1c21fa984926773cc014227a93b41d
tested_at: 370002b8ec1c21fa984926773cc014227a93b41d
scope: live identity YAML nesting and field casing; documentation claims; optional-field schema; link validity; command-doc drift; diff hygiene; review remediation
automated_checks: repository Control Plane link check passed; command-doc check passed; diff check passed; focused content checks passed; independent Codex review clean
manual_checks: durable sanitized read-only evidence records 29 identities and 227 resources across four accessible orgs; no live values or secrets retained; point-in-time counts absent from permanent guide
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable; no user-visible UI changed
paint_check: not applicable; no painted or rendered surface changed
interaction_change: no
interaction_evidence: not applicable; documentation only
visual_fix: no
negative_control: not applicable; no visual fix
performance_impact: not_applicable
performance_evidence: not applicable; no performance-sensitive path changed
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

### Coordination

- Batch: `cpf-20260902-post413-closeout`
- Lane: PR #448 / issue #332 / `jg-codex/332-verify-networkresources`
- Stage gate: push, final validation, and merge permissions eligible for this lane; #447 remains separately dependency-gated behind issue #428
- Merge: not performed

</details>
