### PR TITLE
Fix review app intent comment permissions

### DIFF
--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -25,7 +25,8 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      # PR issue comments use the Issues API path but require PR write access.
+      pull-requests: write
     outputs:
       allowed: ${{ steps.record.outputs.accepted || steps.intent.outputs.reuse }}
     steps:

--- a/.github/workflows/cpflow-delete-review-app.yml
+++ b/.github/workflows/cpflow-delete-review-app.yml
@@ -23,8 +23,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: read
-      contents: read
-      issues: write
       # PR issue comments use the Issues API path but require PR write access.
       pull-requests: write
     outputs:

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -33,8 +33,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: read
-      contents: read
-      issues: write
       # PR issue comments use the Issues API path but require PR write access.
       pull-requests: write
     outputs:

--- a/.github/workflows/cpflow-deploy-review-app.yml
+++ b/.github/workflows/cpflow-deploy-review-app.yml
@@ -35,7 +35,8 @@ jobs:
       actions: read
       contents: read
       issues: write
-      pull-requests: read
+      # PR issue comments use the Issues API path but require PR write access.
+      pull-requests: write
     outputs:
       allowed: ${{ steps.record.outputs.accepted || steps.intent.outputs.reuse }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
-- **Fixed review-app deploy and delete authorization failing while recording accepted intent comments.** The authorization job now has the PR write permission GitHub requires to post bot-owned comments on pull requests. Follow-up to [issue 442](https://github.com/shakacode/control-plane-flow/issues/442).
+- **Fixed review-app deploy and delete authorization failing while recording accepted intent comments.** [PR 449](https://github.com/shakacode/control-plane-flow/pull/449) by [Justin Gordon](https://github.com/justin808). The authorization job now has the PR write permission GitHub requires to post bot-owned comments on pull requests. Follow-up to [issue 442](https://github.com/shakacode/control-plane-flow/issues/442).
 - **Made successful review-app checks report when they skipped the Docker image build.** The reusable workflow now writes
   a prominent no-build summary and exposes `image_built=false`, while generated guidance explains that repositories
   needing Dockerfile validation should use a separate required build gate. Fixes [issue 412](https://github.com/shakacode/control-plane-flow/issues/412).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Fixed review-app deploy and delete authorization failing while recording accepted intent comments.** The authorization job now has the PR write permission GitHub requires to post bot-owned comments on pull requests. Follow-up to [issue 442](https://github.com/shakacode/control-plane-flow/issues/442).
 - **Made successful review-app checks report when they skipped the Docker image build.** The reusable workflow now writes
   a prominent no-build summary and exposes `image_built=false`, while generated guidance explains that repositories
   needing Dockerfile validation should use a separate required build gate. Fixes [issue 412](https://github.com/shakacode/control-plane-flow/issues/412).

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -608,7 +608,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
           "actions" => "read",
           "contents" => "read",
           "issues" => "write",
-          "pull-requests" => "read"
+          "pull-requests" => "write"
         )
         expect(authorization_job.fetch("outputs")).to eq(
           "allowed" => "${{ steps.record.outputs.accepted || steps.intent.outputs.reuse }}"

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -606,8 +606,6 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
         expect(workflow.fetch("permissions")).to include("actions" => "write", "issues" => "write")
         expect(authorization_job.fetch("permissions")).to eq(
           "actions" => "read",
-          "contents" => "read",
-          "issues" => "write",
           "pull-requests" => "write"
         )
         expect(authorization_job.fetch("outputs")).to eq(
@@ -663,7 +661,10 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       generated_wrappers.each do |contents|
         wrapper = YAML.safe_load(contents, aliases: true)
         triggers = wrapper["on"] || wrapper.fetch(true)
-        expect(wrapper.fetch("permissions")).to include("actions" => "write")
+        expect(wrapper.fetch("permissions")).to include(
+          "actions" => "write",
+          "pull-requests" => "write"
+        )
         expect(triggers.dig("workflow_dispatch", "inputs", "reconcile_intent_run_id")).to include(
           "required" => false,
           "type" => "string"

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
           "actions" => "read",
           "contents" => "read",
           "issues" => "write",
-          "pull-requests" => "read"
+          "pull-requests" => "write"
         )
         expect(authorization_job.fetch("outputs")).to eq(
           "allowed" => "${{ steps.record.outputs.accepted || steps.intent.outputs.reuse }}"

--- a/spec/github_workflows_spec.rb
+++ b/spec/github_workflows_spec.rb
@@ -36,8 +36,6 @@ RSpec.describe "GitHub workflow definitions" do # rubocop:disable RSpec/Describe
         expect(workflow.fetch("permissions")).to include("actions" => "write", "issues" => "write")
         expect(authorization_job.fetch("permissions")).to eq(
           "actions" => "read",
-          "contents" => "read",
-          "issues" => "write",
           "pull-requests" => "write"
         )
         expect(authorization_job.fetch("outputs")).to eq(


### PR DESCRIPTION
## Why

The post-merge exercise for #440 reached the new durable-intent step but failed with HTTP 403 before any Control Plane resource was created. The authorization jobs post bot-owned comments on pull requests; `issues: write` plus `pull-requests: read` was insufficient for that PR mutation.

## What changed

- Give the deploy and delete `authorize-comment-command` jobs only `actions: read` plus `pull-requests: write`.
- Remove unnecessary content and issue grants from those now-write-capable jobs; keep the ordering logic unchanged.
- Lock the reusable-job and generated-caller permission contracts into both spec surfaces, and document the fix in the changelog.

## How to review and verify

1. Confirm the permission change is confined to the two authorization jobs.
2. Review the two regression expectations and the unchanged surrounding authorization contract.
3. Check the current-head hosted results and the exact-head consumer rerun linked from #442 before merge.

## Related issues

Part of #442. The exact-head consumer exercise and cleanup satisfy #407. Issue #442 remains open for its broader rapid-operation reconciliation and real read/triage-denial exercises.

## Checklist

- [x] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
- [x] The change is focused and contains no unrelated cleanup or generated churn.
- [x] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
- [x] I reviewed and understand all submitted content, including AI-assisted changes.

<details>
<summary>Agent details</summary>

### Verification

- Exact base: `082a3952eb6282e6e669fa5d175b71633026e3a7`.
- Candidate head: `b66515cbb564665dabc81bfcb615a4be20b1eaaf`.
- Patch digest: `8fce0e576d1bb20eb3a0b0ad246e85bbba4391b9747fd80a10e5c3c3f50a42b2`.
- Focused red control failed exactly for the two stale `pull-requests: read` expectations.
- Focused green suite: 106 examples, 0 failures.
- Lint: 213 files, no offenses.
- Docs, YAML parsing, and diff check: passed.
- `actionlint`: no diagnostic delta from exact base.
- Trusted Secure GitHub Actions scan: 120 findings on base and head, with identical finding-ID digest `5e2cba67760d6807446d4724dd733347cdf00d9599e6112d24fceaa4130ff654`.
- Full validation was attempted; live Control Plane examples require a local `CPLN_ORG`, while the complete focused offline surface is green.
- Independent review found unnecessary job grants and missing caller-side permission coverage; both findings are fixed in this head. Hosted review also requested changelog traceability, now supplied with the PR and author links.

### Runtime evidence

- Pre-fix failing run: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33584840920
- No GVC, workload, or deployment was created by the failed run.
- Exact-head pull-request sync: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33585942789
- Exact-head templated-domain deploy: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33586029380
- Normalized URL evidence: `https://verification.example.test/octochangelog-on-rails-pro-review-pr-37?alias=1kj6ebmqchjyp` in https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/pull/37#issuecomment-5503749417
- Exact-head empty-domain fallback deploy: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33586465658
- Raw-endpoint fallback evidence: `https://rails-1kj6ebmqchjyp.cpln.app` in https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/pull/37#issuecomment-5503799359
- A stale disposable delete wrapper was deliberately retained as evidence in failed run https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33586755003; its authorization/comment step passed before provenance validation correctly rejected the old caller contract.
- The generated caller contract was restored and cleanup passed: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33586908614
- The post-close delete path also passed idempotently: https://github.com/shakacode/react_on_rails-demo-octochangelog-on-rails-pro/actions/runs/33587006065
- Cleanup verified: GVC absent, both GitHub deployments inactive, disposable PR #37 closed unmerged, and its remote branch deleted.

### QA Evidence

- QA required: yes.
- QA lane status: satisfied.
- Release-blocking status: clear.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: b66515cbb564665dabc81bfcb615a4be20b1eaaf
tested_at: 2026-09-02 exact head b66515cbb564665dabc81bfcb615a4be20b1eaaf based on 082a3952eb6282e6e669fa5d175b71633026e3a7; hosted deploy, fallback, delete, and post-close cleanup complete
scope: deploy and delete authorization-job permission required to record durable bot-owned PR intent comments
automated_checks: 106 focused specs; lint; docs; YAML parse; diff check; actionlint baseline equivalence; trusted security-scan baseline equivalence
manual_checks: exact-head hosted pull-request sync, templated-domain deploy, empty-domain fallback, corrected delete, post-close idempotent cleanup, GVC absence, inactive deployments, and disposable PR/branch removal
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no user-visible UI change
interaction_change: no
interaction_evidence: not applicable: workflow authorization behavior only
visual_fix: no
negative_control: not applicable: behavior-contract fix with durable pre-fix hosted failure as the control
performance_impact: not_applicable
performance_evidence: not applicable: permission metadata and contract specs only
findings: stale disposable delete wrapper correctly failed provenance validation and was updated to the generated caller contract; no PR #449 regression or release blocker remains
release_blocking: clear
process_gap_disposition: checklist+replay
-->

### Coordination

- Batch: `cpflow-justin808-cleanout-20260901`
- Lane: issue #442 / `jg-codex/442-review-intent-permission`
- Existing tracker #442 remains open through the runtime rerun.

</details>
