### PR TITLE
Bound cpflow run status reconciliation after command completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 - **Trimmed the RubyGems post-install message to a three-line generated-workflow reminder with a link to the full update and validation instructions.** Fixes [issue 377](https://github.com/shakacode/control-plane-flow/issues/377).
 
+### Fixed
+
+- **Bounded `cpflow run` status reconciliation after a non-interactive command finishes.** When Control Plane keeps reporting a cron job as active or pending after the command completion marker, `cpflow run` now waits up to a configurable 20-minute grace period and then exits nonzero with the job, replica, and last observed status instead of polling forever. Addresses the bounded-reconciliation portion of [HiChee issue 10375](https://github.com/shakacode/hichee/issues/10375).
+
 ## [5.3.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -307,6 +307,11 @@ aliases:
     # If not specified, defaults to 21600 (6 hours).
     runner_job_timeout: 1000
 
+    # Sets how long `cpflow run` waits for Control Plane to reconcile a cron job status
+    # after the non-interactive command prints its completion marker.
+    # If not specified, defaults to 1200 (20 minutes).
+    runner_job_status_reconciliation_timeout: 1200
+
     # Apps with a deployed image, or an image-less GVC, created before this amount of days
     # will be listed for deletion when running the command `cpflow cleanup-stale-apps`.
     stale_app_image_deployed_days: 5

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -483,6 +483,10 @@ timeout 300 cpflow ps:wait -a $APP_NAME
   (can be configured though `runner_job_timeout` in `controlplane.yml`)
 - Waiting for a runner replica is limited to the smaller of `runner_job_timeout` and 1000 seconds.
   A terminal cron status fails immediately, and reaching the observation deadline reports the last safe status
+- After a non-interactive command prints its completion marker, Control Plane has up to 20 minutes to
+  reconcile the cron job to a terminal status. This can be configured through
+  `runner_job_status_reconciliation_timeout` in `controlplane.yml`; timing out exits nonzero and reports
+  the job, replica, and last observed status
 - Non-interactive jobs return the Control Plane cron job status even when the job finishes before
   Control Plane exposes a runner replica to attach logs to
 - Injects `CPFLOW_GVC_ID` and `CPFLOW_GVC_CREATED` into the job, exposing the app's immutable GVC

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -483,10 +483,12 @@ timeout 300 cpflow ps:wait -a $APP_NAME
   (can be configured though `runner_job_timeout` in `controlplane.yml`)
 - Waiting for a runner replica is limited to the smaller of `runner_job_timeout` and 1000 seconds.
   A terminal cron status fails immediately, and reaching the observation deadline reports the last safe status
-- After a non-interactive command prints its completion marker, Control Plane has up to 20 minutes to
-  reconcile the cron job to a terminal status. This can be configured through
+- With non-interactive log methods 2 and 3, after a command prints its completion marker, Control Plane
+  has up to 20 minutes to reconcile the cron job to a terminal status. This can be configured through
   `runner_job_status_reconciliation_timeout` in `controlplane.yml`; timing out exits nonzero and reports
   the job, replica, and last observed status
+- Log method 1 does not emit a completion marker, so its job-status polling is not covered by the
+  post-command reconciliation timeout
 - Non-interactive jobs return the Control Plane cron job status even when the job finishes before
   Control Plane exposes a runner replica to attach logs to
 - Injects `CPFLOW_GVC_ID` and `CPFLOW_GVC_CREATED` into the job, exposing the app's immutable GVC

--- a/examples/controlplane.yml
+++ b/examples/controlplane.yml
@@ -104,6 +104,11 @@ aliases:
     # If not specified, defaults to 21600 (6 hours).
     runner_job_timeout: 1000
 
+    # Sets how long `cpflow run` waits for Control Plane to reconcile a cron job status
+    # after the non-interactive command prints its completion marker.
+    # If not specified, defaults to 1200 (20 minutes).
+    runner_job_status_reconciliation_timeout: 1200
+
     # Apps with a deployed image created before this amount of days will be listed for deletion
     # when running the command `cpflow cleanup-stale-apps`.
     stale_app_image_deployed_days: 5

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -659,7 +659,7 @@ module Command
       )
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def resolve_job_status(status_deadline: nil)
       last_status = @last_job_status
       loop do
@@ -669,12 +669,14 @@ module Command
           break ExitCode::ERROR_DEFAULT
         end
 
-        request_timeout = [JOB_STATUS_REQUEST_TIMEOUT_SECONDS, remaining_seconds].min if remaining_seconds
+        request_timeout = if remaining_seconds
+                            [JOB_STATUS_REQUEST_TIMEOUT_SECONDS, remaining_seconds].min
+                          else
+                            JOB_STATUS_REQUEST_TIMEOUT_SECONDS
+                          end
         begin
           status = current_job_status(timeout_seconds: request_timeout)
         rescue Shell::CommandTimeout
-          raise unless status_deadline
-
           next
         end
         last_status = status
@@ -694,7 +696,7 @@ module Command
         end
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def current_job_status(timeout_seconds: nil)
       result = if timeout_seconds

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -49,6 +49,10 @@ module Command
         (can be configured though `runner_job_timeout` in `controlplane.yml`)
       - Waiting for a runner replica is limited to the smaller of `runner_job_timeout` and 1000 seconds.
         A terminal cron status fails immediately, and reaching the observation deadline reports the last safe status
+      - After a non-interactive command prints its completion marker, Control Plane has up to 20 minutes to
+        reconcile the cron job to a terminal status. This can be configured through
+        `runner_job_status_reconciliation_timeout` in `controlplane.yml`; timing out exits nonzero and reports
+        the job, replica, and last observed status
       - Non-interactive jobs return the Control Plane cron job status even when the job finishes before
         Control Plane exposes a runner replica to attach logs to
       - Injects `CPFLOW_GVC_ID` and `CPFLOW_GVC_CREATED` into the job, exposing the app's immutable GVC
@@ -108,15 +112,18 @@ module Command
     DEFAULT_JOB_CPU = "1"
     DEFAULT_JOB_MEMORY = "2Gi"
     DEFAULT_JOB_TIMEOUT = 21_600 # 6 hours
+    DEFAULT_JOB_STATUS_RECONCILIATION_TIMEOUT = 1_200 # 20 minutes
     DEFAULT_JOB_HISTORY_LIMIT = 10
     MAX_REPLICA_OBSERVATION_SECONDS = 1_000
     REPLICA_OBSERVATION_POLL_INTERVAL_SECONDS = 1
+    JOB_STATUS_POLL_INTERVAL_SECONDS = 1
     NORMALIZED_JOB_STATUS_PATTERN = /\A[a-z][a-z0-9_-]{0,31}\z/
     MAGIC_END = "---cpflow run command finished---"
 
     attr_reader :interactive, :detached, :location, :original_workload, :runner_workload,
                 :default_image, :default_cpu, :default_memory, :job_timeout, :job_history_limit,
-                :container, :job, :replica, :command, :job_completed_before_replica_exit_status
+                :job_status_reconciliation_timeout, :container, :job, :replica, :command,
+                :job_completed_before_replica_exit_status
 
     def call # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       @interactive = config.options[:interactive] || interactive_command?
@@ -130,6 +137,8 @@ module Command
       @default_cpu = config.current[:runner_job_default_cpu] || DEFAULT_JOB_CPU
       @default_memory = config.current[:runner_job_default_memory] || DEFAULT_JOB_MEMORY
       @job_timeout = config.current[:runner_job_timeout] || DEFAULT_JOB_TIMEOUT
+      @job_status_reconciliation_timeout =
+        config.current[:runner_job_status_reconciliation_timeout] || DEFAULT_JOB_STATUS_RECONCILIATION_TIMEOUT
       @job_history_limit = DEFAULT_JOB_HISTORY_LIMIT
 
       unless interactive
@@ -614,6 +623,7 @@ module Command
 
     def wait_for_job_status_and_log(logs_pipe) # rubocop:disable Metrics/MethodLength
       no_logs_counter = 0
+      command_finished = false
 
       loop do
         no_logs_counter += 1
@@ -623,12 +633,16 @@ module Command
 
         no_logs_counter = 0
         line = logs_pipe.gets
-        break if line.chomp == MAGIC_END
+        if line.chomp == MAGIC_END
+          command_finished = true
+          break
+        end
 
         puts(line)
       end
 
-      resolve_job_status
+      status_deadline = job_status_reconciliation_deadline if command_finished
+      resolve_job_status(status_deadline: status_deadline)
     end
 
     def print_detached_commands
@@ -642,7 +656,7 @@ module Command
       )
     end
 
-    def resolve_job_status # rubocop:disable Metrics/MethodLength
+    def resolve_job_status(status_deadline: nil) # rubocop:disable Metrics/MethodLength
       loop do
         status = current_job_status
 
@@ -650,7 +664,17 @@ module Command
 
         case status
         when "active", "pending"
-          sleep 1
+          sleep_seconds = JOB_STATUS_POLL_INTERVAL_SECONDS
+          if status_deadline
+            remaining_seconds = status_deadline - monotonic_time
+            if remaining_seconds <= 0
+              progress.puts(Shell.color(job_status_reconciliation_timeout_message(status), :red))
+              break ExitCode::ERROR_DEFAULT
+            end
+
+            sleep_seconds = [sleep_seconds, remaining_seconds].min
+          end
+          Kernel.sleep(sleep_seconds) if sleep_seconds.positive?
         when "successful"
           break ExitCode::SUCCESS
         else
@@ -665,6 +689,23 @@ module Command
       job_details&.dig("status")
     end
 
+    def job_status_reconciliation_deadline
+      monotonic_time + job_status_reconciliation_timeout
+    end
+
+    def job_status_reconciliation_timeout_message(status)
+      replica_args = app_workload_replica_args.join(" ")
+
+      <<~MESSAGE.chomp
+        ERROR: Control Plane job status did not reconcile within #{job_status_reconciliation_timeout} seconds after the command finished.
+        job: #{job}
+        replica: #{replica}
+        status: #{status || 'unknown'}
+        Inspect logs: cpflow logs #{replica_args}
+        Stop the stale runner: cpflow ps:stop #{replica_args}
+      MESSAGE
+    end
+
     ###########################################
     ### temporary extaction from run:detached
     ###########################################
@@ -672,9 +713,11 @@ module Command
       retries = 0
       begin
         job_finished_count = 0
+        status_deadline = nil
         loop do
           case print_uniq_logs
           when :finished
+            status_deadline = job_status_reconciliation_deadline
             break
           when :changed
             next
@@ -686,7 +729,7 @@ module Command
           end
         end
 
-        resolve_job_status
+        resolve_job_status(status_deadline: status_deadline)
       rescue RuntimeError => e
         raise "#{e} Exiting..." unless retries < 10 # MAX_RETRIES
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -49,10 +49,12 @@ module Command
         (can be configured though `runner_job_timeout` in `controlplane.yml`)
       - Waiting for a runner replica is limited to the smaller of `runner_job_timeout` and 1000 seconds.
         A terminal cron status fails immediately, and reaching the observation deadline reports the last safe status
-      - After a non-interactive command prints its completion marker, Control Plane has up to 20 minutes to
-        reconcile the cron job to a terminal status. This can be configured through
+      - With non-interactive log methods 2 and 3, after a command prints its completion marker, Control Plane
+        has up to 20 minutes to reconcile the cron job to a terminal status. This can be configured through
         `runner_job_status_reconciliation_timeout` in `controlplane.yml`; timing out exits nonzero and reports
         the job, replica, and last observed status
+      - Log method 1 does not emit a completion marker, so its job-status polling is not covered by the
+        post-command reconciliation timeout
       - Non-interactive jobs return the Control Plane cron job status even when the job finishes before
         Control Plane exposes a runner replica to attach logs to
       - Injects `CPFLOW_GVC_ID` and `CPFLOW_GVC_CREATED` into the job, exposing the app's immutable GVC
@@ -117,6 +119,7 @@ module Command
     MAX_REPLICA_OBSERVATION_SECONDS = 1_000
     REPLICA_OBSERVATION_POLL_INTERVAL_SECONDS = 1
     JOB_STATUS_POLL_INTERVAL_SECONDS = 1
+    JOB_STATUS_REQUEST_TIMEOUT_SECONDS = 30
     NORMALIZED_JOB_STATUS_PATTERN = /\A[a-z][a-z0-9_-]{0,31}\z/
     MAGIC_END = "---cpflow run command finished---"
 
@@ -656,24 +659,26 @@ module Command
       )
     end
 
-    def resolve_job_status(status_deadline: nil) # rubocop:disable Metrics/MethodLength
+    def resolve_job_status(status_deadline: nil) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+      last_status = @last_job_status
       loop do
-        status = current_job_status
+        remaining_seconds = status_deadline && (status_deadline - monotonic_time)
+        if remaining_seconds && remaining_seconds <= 0
+          progress.puts(Shell.color(job_status_reconciliation_timeout_message(last_status), :red))
+          break ExitCode::ERROR_DEFAULT
+        end
+
+        request_timeout = [JOB_STATUS_REQUEST_TIMEOUT_SECONDS, remaining_seconds].compact.min
+        status = current_job_status(timeout_seconds: request_timeout)
+        last_status = status
+        @last_job_status = status
 
         Shell.debug("JOB STATUS", status)
 
         case status
         when "active", "pending"
           sleep_seconds = JOB_STATUS_POLL_INTERVAL_SECONDS
-          if status_deadline
-            remaining_seconds = status_deadline - monotonic_time
-            if remaining_seconds <= 0
-              progress.puts(Shell.color(job_status_reconciliation_timeout_message(status), :red))
-              break ExitCode::ERROR_DEFAULT
-            end
-
-            sleep_seconds = [sleep_seconds, remaining_seconds].min
-          end
+          sleep_seconds = [sleep_seconds, remaining_seconds].min if remaining_seconds
           Kernel.sleep(sleep_seconds) if sleep_seconds.positive?
         when "successful"
           break ExitCode::SUCCESS
@@ -681,10 +686,17 @@ module Command
           break ExitCode::ERROR_DEFAULT
         end
       end
+    rescue Shell::CommandTimeout
+      progress.puts(Shell.color(job_status_reconciliation_timeout_message(last_status), :red))
+      ExitCode::ERROR_DEFAULT
     end
 
-    def current_job_status
-      result = cp.fetch_cron_workload(runner_workload, location: location)
+    def current_job_status(timeout_seconds: nil)
+      result = if timeout_seconds
+                 cp.fetch_cron_workload(runner_workload, location: location, timeout_seconds: timeout_seconds)
+               else
+                 cp.fetch_cron_workload(runner_workload, location: location)
+               end
       job_details = result&.dig("items")&.find { |item| item["id"] == job }
       job_details&.dig("status")
     end
@@ -709,23 +721,26 @@ module Command
     ###########################################
     ### temporary extaction from run:detached
     ###########################################
-    def show_logs_waiting # rubocop:disable Metrics/MethodLength
+    def show_logs_waiting # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
       retries = 0
+      status_deadline = nil
       begin
         job_finished_count = 0
-        status_deadline = nil
-        loop do
-          case print_uniq_logs
-          when :finished
-            status_deadline = job_status_reconciliation_deadline
-            break
-          when :changed
-            next
-          else
-            job_finished_count += 1 if resolve_job_status
-            break if job_finished_count > 5
+        unless status_deadline
+          loop do
+            case print_uniq_logs
+            when :finished
+              status_deadline = job_status_reconciliation_deadline
+              break
+            when :changed
+              next
+            else
+              status = current_job_status(timeout_seconds: JOB_STATUS_REQUEST_TIMEOUT_SECONDS)
+              job_finished_count = %w[active pending].include?(status) ? 0 : job_finished_count + 1
+              break if job_finished_count > 5
 
-            sleep(1)
+              sleep(1)
+            end
           end
         end
 

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -745,9 +745,12 @@ module Command
               status = current_job_status(timeout_seconds: JOB_STATUS_REQUEST_TIMEOUT_SECONDS)
               @last_job_status = status
               job_finished_count = %w[active pending].include?(status) ? 0 : job_finished_count + 1
-              break if job_finished_count > 5
+              if job_finished_count > 5
+                status_deadline = job_status_reconciliation_deadline
+                break
+              end
 
-              sleep(1)
+              Kernel.sleep(1)
             end
           end
         end

--- a/lib/command/run.rb
+++ b/lib/command/run.rb
@@ -659,7 +659,8 @@ module Command
       )
     end
 
-    def resolve_job_status(status_deadline: nil) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def resolve_job_status(status_deadline: nil)
       last_status = @last_job_status
       loop do
         remaining_seconds = status_deadline && (status_deadline - monotonic_time)
@@ -668,8 +669,14 @@ module Command
           break ExitCode::ERROR_DEFAULT
         end
 
-        request_timeout = [JOB_STATUS_REQUEST_TIMEOUT_SECONDS, remaining_seconds].compact.min
-        status = current_job_status(timeout_seconds: request_timeout)
+        request_timeout = [JOB_STATUS_REQUEST_TIMEOUT_SECONDS, remaining_seconds].min if remaining_seconds
+        begin
+          status = current_job_status(timeout_seconds: request_timeout)
+        rescue Shell::CommandTimeout
+          raise unless status_deadline
+
+          next
+        end
         last_status = status
         @last_job_status = status
 
@@ -686,10 +693,8 @@ module Command
           break ExitCode::ERROR_DEFAULT
         end
       end
-    rescue Shell::CommandTimeout
-      progress.puts(Shell.color(job_status_reconciliation_timeout_message(last_status), :red))
-      ExitCode::ERROR_DEFAULT
     end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
     def current_job_status(timeout_seconds: nil)
       result = if timeout_seconds
@@ -736,6 +741,7 @@ module Command
               next
             else
               status = current_job_status(timeout_seconds: JOB_STATUS_REQUEST_TIMEOUT_SECONDS)
+              @last_job_status = status
               job_finished_count = %w[active pending].include?(status) ? 0 : job_finished_count + 1
               break if job_finished_count > 5
 

--- a/lib/core/controlplane.rb
+++ b/lib/core/controlplane.rb
@@ -322,9 +322,9 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     end
   end
 
-  def fetch_cron_workload(workload, location:)
+  def fetch_cron_workload(workload, location:, timeout_seconds: nil)
     cmd = "cpln workload cron get #{workload} #{gvc_org} --location #{location} -o yaml"
-    perform_yaml(cmd)
+    perform_yaml(cmd, timeout_seconds: timeout_seconds)
   end
 
   def cron_workload_deployed_version(workload)
@@ -591,10 +591,14 @@ class Controlplane # rubocop:disable Metrics/ClassLength
     success || Shell.abort("Command exited with non-zero status.")
   end
 
-  def perform_yaml(cmd)
+  def perform_yaml(cmd, timeout_seconds: nil)
     Shell.debug("CMD", cmd)
 
-    result = Shell.cmd(cmd)
+    result = if timeout_seconds
+               Shell.cmd(cmd, timeout_seconds: timeout_seconds)
+             else
+               Shell.cmd(cmd)
+             end
     YAML.safe_load(result[:output], permitted_classes: [Time]) if result[:success]
   end
 

--- a/lib/core/shell.rb
+++ b/lib/core/shell.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Shell
+  class CommandTimeout < RuntimeError; end
+
   class << self
     attr_reader :tmp_stderr, :verbose
   end
@@ -9,8 +11,8 @@ class Shell
     @tmp_stderr = Tempfile.create
 
     yield
-
-    @tmp_stderr.close
+  ensure
+    @tmp_stderr&.close
     @tmp_stderr = nil
   end
 
@@ -65,7 +67,9 @@ class Shell
     tmp_stderr && !verbose
   end
 
-  def self.cmd(*cmd_to_run, capture_stderr: false, separate_stderr: false)
+  def self.cmd(*cmd_to_run, capture_stderr: false, separate_stderr: false, timeout_seconds: nil)
+    return timed_cmd(cmd_to_run, capture_stderr, separate_stderr, timeout_seconds) if timeout_seconds
+
     return cmd_with_separate_stderr(*cmd_to_run) if separate_stderr
 
     output, status = capture_stderr ? Open3.capture2e(*cmd_to_run) : Open3.capture2(*cmd_to_run)
@@ -74,6 +78,16 @@ class Shell
       success: status.success?
     }
   end
+
+  def self.timed_cmd(cmd_to_run, capture_stderr, separate_stderr, timeout_seconds)
+    TimedCommand.capture(
+      *cmd_to_run,
+      capture_stderr: capture_stderr,
+      separate_stderr: separate_stderr,
+      timeout_seconds: timeout_seconds
+    )
+  end
+  private_class_method :timed_cmd
 
   def self.cmd_with_separate_stderr(*cmd_to_run)
     output, error_output, status = Open3.capture3(*cmd_to_run)

--- a/lib/core/timed_command.rb
+++ b/lib/core/timed_command.rb
@@ -68,6 +68,8 @@ class TimedCommand
     return if observed_threads.all? { |thread| thread.join(remaining_timeout) }
 
     terminate_process_group(wait_thread)
+    output_readers.each(&:kill)
+    output_readers.each(&:join)
     raise Shell::CommandTimeout, "Command exceeded the #{@timeout_seconds}-second timeout"
   end
 

--- a/lib/core/timed_command.rb
+++ b/lib/core/timed_command.rb
@@ -16,6 +16,7 @@ class TimedCommand
 
   def capture
     @deadline = monotonic_time + @timeout_seconds
+    @command_cleaned_up = false
     return capture_separate_streams if @separate_stderr
     return capture_merged_streams if @capture_stderr
 
@@ -24,40 +25,49 @@ class TimedCommand
 
   private
 
-  def capture_stdout
+  def capture_stdout # rubocop:disable Metrics/MethodLength
+    completed = false
     Open3.popen2(*@command, pgroup: true) do |stdin, stdout, wait_thread|
       stdin.close
       output_reader = Thread.new { stdout.read }
       wait_for_command(wait_thread, output_reader)
+      completed = true
       { output: output_reader.value, success: wait_thread.value.success? }
     ensure
+      cleanup_unfinished_command(wait_thread, output_reader) unless completed || @command_cleaned_up
       output_reader&.join
     end
   end
 
-  def capture_merged_streams
+  def capture_merged_streams # rubocop:disable Metrics/MethodLength
+    completed = false
     Open3.popen2e(*@command, pgroup: true) do |stdin, output, wait_thread|
       stdin.close
       output_reader = Thread.new { output.read }
       wait_for_command(wait_thread, output_reader)
+      completed = true
       { output: output_reader.value, success: wait_thread.value.success? }
     ensure
+      cleanup_unfinished_command(wait_thread, output_reader) unless completed || @command_cleaned_up
       output_reader&.join
     end
   end
 
   def capture_separate_streams # rubocop:disable Metrics/MethodLength
+    completed = false
     Open3.popen3(*@command, pgroup: true) do |stdin, stdout, stderr, wait_thread|
       stdin.close
       output_reader = Thread.new { stdout.read }
       error_reader = Thread.new { stderr.read }
       wait_for_command(wait_thread, output_reader, error_reader)
+      completed = true
       {
         output: output_reader.value,
         error_output: error_reader.value,
         success: wait_thread.value.success?
       }
     ensure
+      cleanup_unfinished_command(wait_thread, output_reader, error_reader) unless completed || @command_cleaned_up
       output_reader&.join
       error_reader&.join
     end
@@ -70,6 +80,7 @@ class TimedCommand
     terminate_process_group(wait_thread)
     output_readers.each(&:kill)
     output_readers.each(&:join)
+    @command_cleaned_up = true
     raise Shell::CommandTimeout, "Command exceeded the #{@timeout_seconds}-second timeout"
   end
 
@@ -89,5 +100,12 @@ class TimedCommand
     wait_thread.join
   rescue Errno::ESRCH, Errno::ECHILD
     nil
+  end
+
+  def cleanup_unfinished_command(wait_thread, *output_readers)
+    return unless wait_thread
+
+    terminate_process_group(wait_thread)
+    output_readers.compact.each(&:kill)
   end
 end

--- a/lib/core/timed_command.rb
+++ b/lib/core/timed_command.rb
@@ -15,6 +15,7 @@ class TimedCommand
   end
 
   def capture
+    @deadline = monotonic_time + @timeout_seconds
     return capture_separate_streams if @separate_stderr
     return capture_merged_streams if @capture_stderr
 
@@ -27,7 +28,7 @@ class TimedCommand
     Open3.popen2(*@command, pgroup: true) do |stdin, stdout, wait_thread|
       stdin.close
       output_reader = Thread.new { stdout.read }
-      wait_for_command(wait_thread)
+      wait_for_command(wait_thread, output_reader)
       { output: output_reader.value, success: wait_thread.value.success? }
     ensure
       output_reader&.join
@@ -38,7 +39,7 @@ class TimedCommand
     Open3.popen2e(*@command, pgroup: true) do |stdin, output, wait_thread|
       stdin.close
       output_reader = Thread.new { output.read }
-      wait_for_command(wait_thread)
+      wait_for_command(wait_thread, output_reader)
       { output: output_reader.value, success: wait_thread.value.success? }
     ensure
       output_reader&.join
@@ -50,7 +51,7 @@ class TimedCommand
       stdin.close
       output_reader = Thread.new { stdout.read }
       error_reader = Thread.new { stderr.read }
-      wait_for_command(wait_thread)
+      wait_for_command(wait_thread, output_reader, error_reader)
       {
         output: output_reader.value,
         error_output: error_reader.value,
@@ -62,11 +63,20 @@ class TimedCommand
     end
   end
 
-  def wait_for_command(wait_thread)
-    return if wait_thread.join(@timeout_seconds)
+  def wait_for_command(wait_thread, *output_readers)
+    observed_threads = [wait_thread, *output_readers]
+    return if observed_threads.all? { |thread| thread.join(remaining_timeout) }
 
     terminate_process_group(wait_thread)
     raise Shell::CommandTimeout, "Command exceeded the #{@timeout_seconds}-second timeout"
+  end
+
+  def remaining_timeout
+    [@deadline - monotonic_time, 0].max
+  end
+
+  def monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
   end
 
   def terminate_process_group(wait_thread)

--- a/lib/core/timed_command.rb
+++ b/lib/core/timed_command.rb
@@ -71,7 +71,7 @@ class TimedCommand
 
   def terminate_process_group(wait_thread)
     Process.kill("TERM", -wait_thread.pid)
-    return if wait_thread.join(1)
+    wait_thread.join(1)
 
     Process.kill("KILL", -wait_thread.pid)
     wait_thread.join

--- a/lib/core/timed_command.rb
+++ b/lib/core/timed_command.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class TimedCommand
+  def self.capture(*command, capture_stderr:, separate_stderr:, timeout_seconds:)
+    new(command, capture_stderr, separate_stderr, timeout_seconds).capture
+  end
+
+  def initialize(command, capture_stderr, separate_stderr, timeout_seconds)
+    raise ArgumentError, "timeout_seconds must be positive" unless timeout_seconds.positive?
+
+    @command = command
+    @capture_stderr = capture_stderr
+    @separate_stderr = separate_stderr
+    @timeout_seconds = timeout_seconds
+  end
+
+  def capture
+    return capture_separate_streams if @separate_stderr
+    return capture_merged_streams if @capture_stderr
+
+    capture_stdout
+  end
+
+  private
+
+  def capture_stdout
+    Open3.popen2(*@command, pgroup: true) do |stdin, stdout, wait_thread|
+      stdin.close
+      output_reader = Thread.new { stdout.read }
+      wait_for_command(wait_thread)
+      { output: output_reader.value, success: wait_thread.value.success? }
+    ensure
+      output_reader&.join
+    end
+  end
+
+  def capture_merged_streams
+    Open3.popen2e(*@command, pgroup: true) do |stdin, output, wait_thread|
+      stdin.close
+      output_reader = Thread.new { output.read }
+      wait_for_command(wait_thread)
+      { output: output_reader.value, success: wait_thread.value.success? }
+    ensure
+      output_reader&.join
+    end
+  end
+
+  def capture_separate_streams # rubocop:disable Metrics/MethodLength
+    Open3.popen3(*@command, pgroup: true) do |stdin, stdout, stderr, wait_thread|
+      stdin.close
+      output_reader = Thread.new { stdout.read }
+      error_reader = Thread.new { stderr.read }
+      wait_for_command(wait_thread)
+      {
+        output: output_reader.value,
+        error_output: error_reader.value,
+        success: wait_thread.value.success?
+      }
+    ensure
+      output_reader&.join
+      error_reader&.join
+    end
+  end
+
+  def wait_for_command(wait_thread)
+    return if wait_thread.join(@timeout_seconds)
+
+    terminate_process_group(wait_thread)
+    raise Shell::CommandTimeout, "Command exceeded the #{@timeout_seconds}-second timeout"
+  end
+
+  def terminate_process_group(wait_thread)
+    Process.kill("TERM", -wait_thread.pid)
+    return if wait_thread.join(1)
+
+    Process.kill("KILL", -wait_thread.pid)
+    wait_thread.join
+  rescue Errno::ESRCH, Errno::ECHILD
+    nil
+  end
+end

--- a/spec/command/deploy_image_unit_spec.rb
+++ b/spec/command/deploy_image_unit_spec.rb
@@ -312,6 +312,13 @@ describe Command::DeployImage do
           .ordered
         expect(command).to have_received(:run_release_script).ordered
       end
+
+      it "does not deploy workloads when the release script fails" do
+        allow(command).to receive(:run_release_script).and_raise("release phase failed")
+
+        expect { command.call }.to raise_error("release phase failed")
+        expect(cp).not_to have_received(:workload_set_image_ref)
+      end
     end
 
     context "when release phase config is invalid" do

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -99,6 +99,62 @@ describe Command::Run do
     end
   end
 
+  describe "post-command job status reconciliation" do
+    let(:config) { instance_double(Config) }
+    let(:cp) { instance_double(Controlplane) }
+    let(:progress) { instance_double(IO, puts: nil) }
+    let(:command) { described_class.new(config) }
+
+    before do
+      allow(config).to receive(:app).and_return("test-app")
+      allow(command).to receive_messages(cp: cp, progress: progress)
+      allow(command).to receive(:print_uniq_logs).and_return(:finished)
+      allow(Kernel).to receive(:sleep)
+
+      command.instance_variable_set(:@job, "job-123")
+      command.instance_variable_set(:@replica, "rails-runner-job-123")
+      command.instance_variable_set(:@location, "aws-us-east-2")
+      command.instance_variable_set(:@runner_workload, "rails-runner")
+      command.instance_variable_set(:@job_status_reconciliation_timeout, 1_200)
+    end
+
+    it "fails after the command marker when an active job never reconciles" do
+      allow(command).to receive(:monotonic_time).and_return(100.0, 1_300.0)
+      status_reads = 0
+      allow(command).to receive(:current_job_status) do
+        status_reads += 1
+        raise "unbounded polling" if status_reads > 1
+
+        "active"
+      end
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
+      expect(progress).to have_received(:puts).with(
+        include(
+          "did not reconcile within 1200 seconds",
+          "job: job-123",
+          "replica: rails-runner-job-123",
+          "status: active"
+        )
+      )
+    end
+
+    it "accepts eventual success within the post-command grace period" do
+      allow(command).to receive(:monotonic_time).and_return(100.0, 200.0)
+      allow(command).to receive(:current_job_status).and_return("active", "successful")
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::SUCCESS)
+    end
+
+    it "applies the same deadline to streamed logs after the command marker" do
+      logs_pipe = instance_double(IO, eof?: false, ready?: true, gets: "#{described_class::MAGIC_END}\n")
+      allow(command).to receive(:monotonic_time).and_return(100.0, 1_300.0)
+      allow(command).to receive(:current_job_status).and_return("pending")
+
+      expect(command.send(:wait_for_job_status_and_log, logs_pipe)).to eq(ExitCode::ERROR_DEFAULT)
+    end
+  end
+
   describe "#update_runner_workload" do
     let(:config) { instance_double(Config) }
     let(:cp) { instance_double(Controlplane) }

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -155,7 +155,7 @@ describe Command::Run do
     end
 
     it "does not let one status request outlive the remaining reconciliation deadline" do
-      allow(command).to receive(:monotonic_time).and_return(100.0, 1_250.0)
+      allow(command).to receive(:monotonic_time).and_return(100.0, 1_250.0, 1_300.0)
       allow(cp).to receive(:fetch_cron_workload).and_raise(Shell::CommandTimeout)
 
       expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
@@ -163,6 +163,33 @@ describe Command::Run do
         "rails-runner",
         location: "aws-us-east-2",
         timeout_seconds: 30
+      )
+    end
+
+    it "retries a bounded status request until the reconciliation deadline" do
+      allow(command).to receive(:monotonic_time).and_return(100.0, 200.0, 200.0)
+      status_reads = 0
+      allow(command).to receive(:current_job_status) do
+        status_reads += 1
+        raise Shell::CommandTimeout if status_reads == 1
+
+        "successful"
+      end
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::SUCCESS)
+      expect(status_reads).to eq(2)
+    end
+
+    it "does not apply the post-marker request timeout without a reconciliation deadline" do
+      allow(cp).to receive(:fetch_cron_workload).with(
+        "rails-runner",
+        location: "aws-us-east-2"
+      ).and_return("items" => [{ "id" => "job-123", "status" => "successful" }])
+
+      expect(command.send(:resolve_job_status)).to eq(ExitCode::SUCCESS)
+      expect(cp).to have_received(:fetch_cron_workload).with(
+        "rails-runner",
+        location: "aws-us-east-2"
       )
     end
 
@@ -189,6 +216,23 @@ describe Command::Run do
 
       expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
       expect(command).to have_received(:print_uniq_logs).once
+      expect(progress_messages.join("\n")).to include("status: active")
+    end
+
+    it "reports the last pre-marker status if the first post-marker request times out" do
+      progress_messages = []
+      allow(progress).to receive(:puts) { |message| progress_messages << message }
+      allow(command).to receive(:print_uniq_logs).and_return(:unchanged, :finished)
+      allow(command).to receive(:monotonic_time).and_return(100.0, 200.0, 1_300.0)
+      status_reads = 0
+      allow(command).to receive(:current_job_status) do
+        status_reads += 1
+        raise Shell::CommandTimeout if status_reads > 1
+
+        "active"
+      end
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
       expect(progress_messages.join("\n")).to include("status: active")
     end
   end

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -134,7 +134,7 @@ describe Command::Run do
           "did not reconcile within 1200 seconds",
           "job: job-123",
           "replica: rails-runner-job-123",
-          "status: active"
+          "status: unknown"
         )
       )
     end
@@ -152,6 +152,44 @@ describe Command::Run do
       allow(command).to receive(:current_job_status).and_return("pending")
 
       expect(command.send(:wait_for_job_status_and_log, logs_pipe)).to eq(ExitCode::ERROR_DEFAULT)
+    end
+
+    it "does not let one status request outlive the remaining reconciliation deadline" do
+      allow(command).to receive(:monotonic_time).and_return(100.0, 1_250.0)
+      allow(cp).to receive(:fetch_cron_workload).and_raise(Shell::CommandTimeout)
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
+      expect(cp).to have_received(:fetch_cron_workload).with(
+        "rails-runner",
+        location: "aws-us-east-2",
+        timeout_seconds: 30
+      )
+    end
+
+    it "keeps reading logs while the pre-marker job status is active" do
+      allow(command).to receive(:print_uniq_logs).and_return(:unchanged, :finished)
+      allow(command).to receive(:current_job_status).and_return("active", "successful")
+      allow(command).to receive(:monotonic_time).and_return(100.0, 200.0)
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::SUCCESS)
+      expect(command).to have_received(:print_uniq_logs).twice
+    end
+
+    it "preserves the reconciliation deadline across transient retries" do
+      progress_messages = []
+      allow(progress).to receive(:puts) { |message| progress_messages << message }
+      allow(command).to receive(:monotonic_time).and_return(100.0, 200.0, 200.0, 1_300.0)
+      status_reads = 0
+      allow(command).to receive(:current_job_status) do
+        status_reads += 1
+        raise "transient status failure" if status_reads > 1
+
+        "active"
+      end
+
+      expect(command.send(:show_logs_waiting)).to eq(ExitCode::ERROR_DEFAULT)
+      expect(command).to have_received(:print_uniq_logs).once
+      expect(progress_messages.join("\n")).to include("status: active")
     end
   end
 

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -180,17 +180,25 @@ describe Command::Run do
       expect(status_reads).to eq(2)
     end
 
-    it "does not apply the post-marker request timeout without a reconciliation deadline" do
+    it "bounds and retries status requests without a reconciliation deadline" do
+      status_reads = 0
       allow(cp).to receive(:fetch_cron_workload).with(
         "rails-runner",
-        location: "aws-us-east-2"
-      ).and_return("items" => [{ "id" => "job-123", "status" => "successful" }])
+        location: "aws-us-east-2",
+        timeout_seconds: 30
+      ) do
+        status_reads += 1
+        raise Shell::CommandTimeout if status_reads == 1
+
+        { "items" => [{ "id" => "job-123", "status" => "successful" }] }
+      end
 
       expect(command.send(:resolve_job_status)).to eq(ExitCode::SUCCESS)
       expect(cp).to have_received(:fetch_cron_workload).with(
         "rails-runner",
-        location: "aws-us-east-2"
-      )
+        location: "aws-us-east-2",
+        timeout_seconds: 30
+      ).twice
     end
 
     it "keeps reading logs while the pre-marker job status is active" do

--- a/spec/command/run_unit_spec.rb
+++ b/spec/command/run_unit_spec.rb
@@ -210,6 +210,20 @@ describe Command::Run do
       expect(command).to have_received(:print_uniq_logs).twice
     end
 
+    it "starts reconciliation when terminal status observations precede the completion marker" do
+      allow(command).to receive_messages(
+        print_uniq_logs: :unchanged,
+        current_job_status: "failed",
+        job_status_reconciliation_deadline: 1234,
+        resolve_job_status: ExitCode::ERROR_DEFAULT
+      )
+
+      command.send(:show_logs_waiting)
+
+      expect(command).to have_received(:resolve_job_status).with(status_deadline: 1234)
+      expect(Kernel).to have_received(:sleep).with(1).exactly(5).times
+    end
+
     it "preserves the reconciliation deadline across transient retries" do
       progress_messages = []
       allow(progress).to receive(:puts) { |message| progress_messages << message }

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -289,6 +289,19 @@ describe Shell do
       expect(elapsed).to be < 2
     end
 
+    it "terminates the command when capture unwinds exceptionally" do
+      timed_command = TimedCommand.new(["sh", "-c", "sleep 5"], false, false, 10)
+      allow(timed_command).to receive(:wait_for_command).and_raise(SystemExit.new(ExitCode::INTERRUPT))
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect do
+        timed_command.capture
+      end.to raise_error(SystemExit) { |error| expect(error.status).to eq(ExitCode::INTERRUPT) }
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 2
+    end
+
     it "preserves merged stderr capture when a timeout is configured" do
       result = described_class.cmd(
         "sh", "-c", "echo captured-err >&2; echo captured-out",

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -265,6 +265,17 @@ describe Shell do
       expect(elapsed).to be < 2
     end
 
+    it "times out when a successful leader leaves a descendant holding output open" do
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect do
+        described_class.cmd("sh", "-c", "sleep 5 & exit 0", timeout_seconds: 0.05)
+      end.to raise_error(described_class::CommandTimeout)
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 2
+    end
+
     it "preserves merged stderr capture when a timeout is configured" do
       result = described_class.cmd(
         "sh", "-c", "echo captured-err >&2; echo captured-out",

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -18,6 +18,14 @@ describe Shell do
       expect(captured_message).to eq("some error")
       expect(described_class.tmp_stderr).to be_nil
     end
+
+    it "clears the tempfile when the block raises" do
+      expect do
+        described_class.use_tmp_stderr { raise "failed command" }
+      end.to raise_error("failed command")
+
+      expect(described_class.tmp_stderr).to be_nil
+    end
   end
 
   describe ".read_from_tmp_stderr" do
@@ -232,6 +240,38 @@ describe Shell do
       result = described_class.cmd("some", "command")
 
       expect(result).to eq(output: "stdout only\n", success: true)
+    end
+
+    it "terminates a command that exceeds its timeout" do
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect do
+        described_class.cmd("sh", "-c", "sleep 5", timeout_seconds: 0.05)
+      end.to raise_error(described_class::CommandTimeout, /0.05-second timeout/)
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 2
+    end
+
+    it "preserves merged stderr capture when a timeout is configured" do
+      result = described_class.cmd(
+        "sh", "-c", "echo captured-err >&2; echo captured-out",
+        capture_stderr: true,
+        timeout_seconds: 1
+      )
+
+      expect(result[:output]).to include("captured-err", "captured-out")
+      expect(result[:success]).to be(true)
+    end
+
+    it "preserves separate stderr capture when a timeout is configured" do
+      result = described_class.cmd(
+        "sh", "-c", "echo captured-err >&2; echo captured-out",
+        separate_stderr: true,
+        timeout_seconds: 1
+      )
+
+      expect(result).to eq(output: "captured-out\n", error_output: "captured-err\n", success: true)
     end
   end
 

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "rbconfig"
 
 describe Shell do
   describe ".use_tmp_stderr" do
@@ -270,6 +271,18 @@ describe Shell do
 
       expect do
         described_class.cmd("sh", "-c", "sleep 5 & exit 0", timeout_seconds: 0.05)
+      end.to raise_error(described_class::CommandTimeout)
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 2
+    end
+
+    it "returns promptly when a descendant escapes the command process group" do
+      command = "#{RbConfig.ruby} -e 'Process.setsid; sleep 3' & exit 0"
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      expect do
+        described_class.cmd("sh", "-c", command, timeout_seconds: 0.05)
       end.to raise_error(described_class::CommandTimeout)
 
       elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at

--- a/spec/core/shell_spec.rb
+++ b/spec/core/shell_spec.rb
@@ -253,6 +253,18 @@ describe Shell do
       expect(elapsed).to be < 2
     end
 
+    it "terminates descendants that keep output open after the leader exits" do
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      command = "trap 'exit 0' TERM; sh -c 'trap \"\" TERM; sleep 5' & wait"
+
+      expect do
+        described_class.cmd("sh", "-c", command, timeout_seconds: 0.05)
+      end.to raise_error(described_class::CommandTimeout)
+
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+      expect(elapsed).to be < 2
+    end
+
     it "preserves merged stderr capture when a timeout is configured" do
       result = described_class.cmd(
         "sh", "-c", "echo captured-err >&2; echo captured-out",


### PR DESCRIPTION
## Summary

- start a monotonic, configurable 20-minute reconciliation deadline after a non-interactive command prints the cpflow completion marker
- fail nonzero with the job, replica, last status, and inspect/stop commands when Control Plane remains active or pending past that deadline
- bound each Control Plane status request, keep reading logs before the marker, and preserve the original deadline and last status across transient retries
- terminate timed-out command groups and stop output readers even when a descendant escapes the original process group
- preserve eventual success within the grace period and verify a failed release phase cannot continue to workload deployment

This addresses only the bounded post-marker reconciliation portion of https://github.com/shakacode/hichee/issues/10375. Cancellation cleanup, concurrent superseding-release prevention, and mixed-version detection remain open follow-up work.

## Known boundaries

Log methods 2 and 3 emit the completion marker and use this post-command reconciliation timeout. Log method 1 does not emit a marker, so it is not covered; applying the 20-minute grace from job start would incorrectly cap legitimate long-running commands.

The pre-replica observation phase still relies on individual `cpln workload replica get` and cron-status subprocesses without per-request timeouts. Its outer observation deadline applies between calls. That broader hardening is outside this post-marker incident patch.

Log method 2 starts the reconciliation deadline only after it reads the completion marker. If its log pipe reaches EOF or stays unreadable for 30 seconds before delivering that marker, it retains the legacy unbounded status polling behavior. Starting the 20-minute deadline from silence alone would incorrectly cap legitimate quiet, long-running commands, so that contract requires separate design work.

## Verification

- Red evidence before the original fix: the stale-active example raised `unbounded polling Exiting...`
- `.agents/bin/test spec/command/run_unit_spec.rb spec/command/deploy_image_unit_spec.rb spec/core/shell_spec.rb` — 109 examples, 0 failures
- `.agents/bin/lint` — 214 files, no offenses
- `.agents/bin/docs` — generated command docs current
- `git diff --check` — clean

## Validation limitation

`.agents/bin/validate` reaches the full Control Plane integration suite, but this host has no `CPLN_ORG` test configuration. The suite fails broadly at command admission with `ERROR: No org provided` before exercising this patch. The deterministic affected unit suites above pass.

## Ownership recommendation

AI with Sergey review. This changes release-path timeout behavior, so it is maintainer-gated and should not merge without Sergey review.
