### PR TITLE
Configure quiet CodeRabbit lifecycle reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+reviews:
+  profile: chill
+  review_status: false
+  review_progress: false
+  in_progress_fortune: false
+  collapse_walkthrough: true
+  auto_review:
+    enabled: false
+    labels:
+      - coderabbit:first-pass
+      - coderabbit:ready

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,10 +2,12 @@ reviews:
   profile: chill
   review_status: false
   review_progress: false
+  commit_status: false
   in_progress_fortune: false
   collapse_walkthrough: true
   auto_review:
     enabled: false
+    auto_incremental_review: false
     labels:
       - coderabbit:first-pass
       - coderabbit:ready

--- a/.github/workflows/coderabbit-lifecycle-review.yml
+++ b/.github/workflows/coderabbit-lifecycle-review.yml
@@ -1,0 +1,28 @@
+name: CodeRabbit Lifecycle Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add CodeRabbit lifecycle label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const label = context.payload.action === 'opened'
+              ? 'coderabbit:first-pass'
+              : 'coderabbit:ready';
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label]
+            });

--- a/.github/workflows/coderabbit-lifecycle-review.yml
+++ b/.github/workflows/coderabbit-lifecycle-review.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add CodeRabbit lifecycle label
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
+          # Both labels must already exist in the repo (addLabels does not create them); created 2026-09-06.
           script: |
             const label = context.payload.action === 'opened'
               ? 'coderabbit:first-pass'

--- a/spec/github_actions_dependency_policy_spec.rb
+++ b/spec/github_actions_dependency_policy_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "GitHub Actions dependency policy" do # rubocop:disable RSpec/Des
       "check_cpln_links.yml" => { "contents" => "read" },
       "claude-code-review.yml" => {},
       "claude.yml" => {},
+      "coderabbit-lifecycle-review.yml" => { "pull-requests" => "write" },
       "command_docs.yml" => { "contents" => "read" },
       "cpflow-cleanup-stale-review-apps.yml" => { "contents" => "read" },
       "cpflow-delete-review-app.yml" => {


### PR DESCRIPTION
## Summary
- trigger CodeRabbit labels only when a PR opens or becomes ready for review
- suppress review status, progress, and fortune noise
- pin the label workflow action and skip fork PRs

## Validation
- GitHub Actions security scan: clean
- .agents/bin/validate: blocked locally because this runner has no CPLN_ORG; credential-dependent integration specs failed before the unrelated workflow diff could be fully validated
- git diff --check: passed

## Rebase and review fixes (2026-09-06)

- Rebased onto `main` at `52685c8a` (#466) so the diff is three added files with no deletions; both original commits are preserved unchanged.
- Registered `coderabbit-lifecycle-review.yml` with `pull-requests: write` in `spec/github_actions_dependency_policy_spec.rb`'s `approved_top_level_permissions`, which is why `RSpec (Fast)` was red: a new workflow file fails the permissions allowlist, the external-action pin audit, and the template pin-drift guard until it is registered.
- Pin comment is now the exact release tag `# v9.0.0`, as the policy spec requires; the SHA already matched every other `actions/github-script` pin.
- `auto_review.enabled: false` is retained on purpose. Per the CodeRabbit configuration reference: "When enabled is false, a positive label match (for example ['review-ready']) triggers a review; negative-only labels such as ['!wip'] remain exclusion filters and do not opt PRs in by themselves." With only positive labels listed, this is the documented opt-in form, and it fails quiet (no reviews) rather than loud (every PR) if the label list is ever emptied.
- The labels `coderabbit:first-pass` and `coderabbit:ready` exist in the repository; `issues.addLabels` does not create labels, so the workflow notes the prerequisite inline.

## Validation at `529ceb4e`

- `CPLN_ORG='' bundle exec rspec` over the documented offline suite plus the workflow, policy, and generator specs: 520 examples, 0 failures
- `.agents/bin/lint` no offenses; `.agents/bin/docs` clean; `git diff --check` clean; `.coderabbit.yaml` parses
- trusted GitHub Actions security scan: CLEAN, 24 files

<details>
<summary>Agent details</summary>

### Commands and results

Worker `cpf-kyoto-pr469-finisher` (isolated worktree): rebase conflict-free; four-spec command 149 examples 0 failures; compatibility-job command 432 examples 0 failures; lint 220/0; docs clean; diff-check clean; trusted scan CLEAN 24/0. Coordinator gate at the same head: 520 examples, 0 failures plus lint, docs, scan, diff-check, YAML parse.

### Exact-head and replay evidence

Base `main` at `52685c8a745602e600c919ebee726bcf816fe0b1`; head `529ceb4efb1862c5a6ebd183838f9dfe71c8889a` (commits `635b59f9` and `b296da2d` rebased from the maintainer's `0579a72c` and `b6183e45`, plus fix commit `529ceb4e`). Batch `cpf-20260904-release-prep-kyoto`, lane `lane-469-coderabbit-lifecycle`, canonical launch `shakacode/control-plane-flow:pull-request:469`; lane taken over at maintainer direction after the prior claim expired.

### QA Evidence

- QA lane: `cpf-kyoto-pr469-finisher` plus coordinator `kyoto-f0`; worktree `.claude/worktrees/agent-a7fadde21b89bd587`; private claim active.
- Scope checked: the new workflow, the CodeRabbit configuration, the permissions-map registration; label existence; CodeRabbit label semantics against the configuration reference.
- Tested at: `529ceb4efb1862c5a6ebd183838f9dfe71c8889a`
- Automated checks: offline suite plus workflow/policy/generator specs, RuboCop, command docs, `git diff --check`, trusted GitHub Actions scan; hosted exact-head CI green: RSpec (Fast) / rspec https://github.com/shakacode/control-plane-flow/actions/runs/34060720690/job/101560643059; Command Docs https://github.com/shakacode/control-plane-flow/actions/runs/34060720531/job/101560642509; claude-review https://github.com/shakacode/control-plane-flow/actions/runs/34060720554/job/101560642660; Check Links https://github.com/shakacode/control-plane-flow/actions/runs/34060720637/job/101560642733; Rubocop https://github.com/shakacode/control-plane-flow/actions/runs/34060720544/job/101560642481; Ruby 3.3 compatibility https://github.com/shakacode/control-plane-flow/actions/runs/34060720690/job/101560642887; Ruby 3.4 compatibility https://github.com/shakacode/control-plane-flow/actions/runs/34060720690/job/101560643028.
- Manual checks: label existence via `gh label list`; CodeRabbit reference fetched and quoted.
- User-visible UI change: no
- Visual evidence: not applicable: no rendered or painted surface changed
- Interaction change: no
- Interaction evidence: not applicable: no UI interaction changed
- Visual fix: no
- Negative control: not applicable: no visual fix
- Performance evidence: not applicable: CI configuration only
- Findings: none
- QA required: yes
- QA required rationale: CI/workflow surface; policy specs, trusted scan, exact-head hosted CI are the required depth.
- QA lane status: satisfied
- Release-blocking status: clear
- Process-gap disposition: checklist+replay

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 529ceb4efb1862c5a6ebd183838f9dfe71c8889a
tested_at: 529ceb4efb1862c5a6ebd183838f9dfe71c8889a
scope: coderabbit-lifecycle-review.yml, .coderabbit.yaml, approved_top_level_permissions registration, label existence, CodeRabbit label semantics
automated_checks: offline suite plus workflow/policy/generator specs at head; RuboCop clean; command docs clean; git diff --check clean; secure-github-actions-scan CLEAN 24/0; hosted exact-head CI green (Check Links, Command Docs, RSpec Fast, Rubocop, Ruby 3.3 and 3.4 compatibility, claude-review, CodeRabbit)
manual_checks: gh label list confirms both labels; CodeRabbit configuration reference quoted for enabled:false plus positive labels
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no rendered or painted surface changed
paint_check: not applicable: no painted or rendered target changed
interaction_change: no
interaction_evidence: not applicable: no UI interaction changed
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: CI configuration only
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<!-- priority-finding-dispositions v1
head_sha: 529ceb4efb1862c5a6ebd183838f9dfe71c8889a
finding: url=https://github.com/shakacode/control-plane-flow/pull/469#discussion_r-codex-permissions-map | severity=P1 | disposition=fixed | evidence=commit 529ceb4efb1862c5a6ebd183838f9dfe71c8889a registers the workflow in approved_top_level_permissions
finding: url=https://github.com/shakacode/control-plane-flow/pull/469#discussion_r-codex-pin-comment | severity=P1 | disposition=fixed | evidence=commit 529ceb4efb1862c5a6ebd183838f9dfe71c8889a uses the exact # v9.0.0 comment
finding: url=https://github.com/shakacode/control-plane-flow/pull/469#discussion_r-codex-enabled | severity=P1 | disposition=false_positive | evidence=CodeRabbit configuration reference: with enabled false, a positive label match triggers a review
-->

### Coordination and reviewer telemetry

Claim `cpf-kyoto-pr469-finisher` (generation 2) on PR 469 after the m5 claim expired; `agent-claimed` label mirrors it. Independent checker `cpf-kyoto-checker` recorded before readiness. Review cohort: claude-review check plus CodeRabbit, Codex, Greptile.

### Decision log

- **Non-blocking:** whether to change `auto_review.enabled` to `true` as a Codex P1 suggested.
  - **Decision:** keep `false`.
  - **Why:** the CodeRabbit reference states positive labels trigger reviews when `enabled` is false; `false` fails quiet if the label list breaks, matching the PR's intent.
  - **Review later:** None
- **Non-blocking:** rebase versus merge.
  - **Decision:** rebase with a lease on the maintainer's latest head, as directed.
  - **Why:** the branch had two small maintainer commits and no conflicts; the pre-rebase diff falsely showed large deletions from #466.
  - **Review later:** None

### Merge confidence

Confidence note: three added files, no runtime change; the workflow is minimal and scanner-clean. CI/workflow changes stay maintainer-gated, so this PR is handed off as `ready-human-review-required` once hosted CI and the review wave are clean.

### Audit receipts

Pending completed-batch audit.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request labeling for initial reviews and reviews ready to begin.
  * Added review workflow configuration to streamline pull request status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

