### PR TITLE
Update changelog for 6.0.0.rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
-## [6.0.0] - 2026-09-06
+## [6.0.0.rc.0] - 2026-09-06
 
 ### Breaking Changes
 
@@ -495,8 +495,8 @@ Deprecated `cpl` gem. New gem is `cpflow`.
 
 First release.
 
-[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v6.0.0...main
-[6.0.0]: https://github.com/shakacode/control-plane-flow/compare/v5.3.0...v6.0.0
+[Unreleased]: https://github.com/shakacode/control-plane-flow/compare/v6.0.0.rc.0...main
+[6.0.0.rc.0]: https://github.com/shakacode/control-plane-flow/compare/v5.3.0...v6.0.0.rc.0
 [5.3.0]: https://github.com/shakacode/control-plane-flow/compare/v5.2.0...v5.3.0
 [5.2.0]: https://github.com/shakacode/control-plane-flow/compare/v5.1.1...v5.2.0
 [5.1.1]: https://github.com/shakacode/control-plane-flow/compare/v5.1.0...v5.1.1


### PR DESCRIPTION
## Why

The next release ships as a release candidate, not a stable 6.0.0. The `6.0.0` section stamped in #465 was never tagged, so it is restamped as `6.0.0.rc.0`.

## What changed

- `## [6.0.0] - 2026-09-06` → `## [6.0.0.rc.0] - 2026-09-06`
- `[Unreleased]` compare link now anchors at `v6.0.0.rc.0`
- `[6.0.0]` compare link becomes `[6.0.0.rc.0]: v5.3.0...v6.0.0.rc.0`

No entry text changed. After this merges, `bundle exec rake release` (no args) reads `6.0.0.rc.0` from the changelog.

## Classification sweep (`v5.3.0..origin/main`)

| PR | Title | Result | Reason |
| --- | --- | --- | --- |
| #448 | Verify Cloud Wormhole networkResources casing | no-entry | Docs-only edit to `docs/rds-private-networking.md` recording verified Control Plane schema evidence; no cpflow behavior documented incorrectly before. |
| #447 | Trim RubyGems post-install message | entry-needed | Already in the section. |
| #453 | Bound `cpflow run` status reconciliation | entry-needed | Already in the section. |
| #451 | Pin GitHub Actions and generate auditable local actions | entry-needed | Already in the section. |
| #457 | Queue all shared-org RSpec waiters | entry-needed | Already in the section. |
| #413 | Fix scheduled slow-suite regressions | entry-needed | Already in the section. |
| #458 | Prevent shell interpretation of Control Plane arguments | entry-needed | Already in the section. |
| #446 | Add ShellCheck CI gate | no-entry | Contributor tooling: `.agents/bin/*`, Rubocop workflow, `script/check_shell_scripts`, and the dummy entrypoint. |
| #464 | Align Ruby support with a 3.2 minimum | entry-needed | Already in the section (Breaking Changes). |
| #460 | Bump pinned GitHub Actions | entry-needed | Already in the section. |
| #465 | Update changelog for 6.0.0 | no-entry | Changelog-only. |
| #467 | Trusted default checkout + `pull_request_target` validator | entry-needed | Already in the section (two entries). |
| #466 | Guard generated-template action pins against drift | no-entry | Spec/CI guard plus contributor docs; no runtime or generated-output change. |
| #469 | Configure quiet CodeRabbit lifecycle reviews | no-entry | Repository CI/bot configuration only. |

No `UNKNOWN` rows.

## Validation

- `bundle exec rspec spec/rakelib/create_release_spec.rb` — 3 examples, 0 failures
- `git diff --check` — clean
- Verified trailing newline, newest-first unique headings, and compare-link endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to identify version 6.0.0 as release candidate 0.
  - Corrected the associated release date and version comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->