### PR TITLE
Make generated pin helper help exit successfully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fixed the generated `bin/pin-cpflow-github-ref` helper so `-h` and `--help` print usage and exit successfully before inspecting repository state.** Fixes [issue 473](https://github.com/shakacode/control-plane-flow/issues/473).
+
 ## [6.0.0.rc.0] - 2026-09-06
 
 ### Breaking Changes

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -591,7 +591,7 @@ cpflow terraform import
 Regenerates the cpflow workflow wrappers, local composite actions, and
 helper files from the currently installed cpflow gem. Use this after
 updating the cpflow gem so checked-in workflow wrappers move to the
-matching upstream release tag, for example `v5.3.0`, and the
+matching upstream release tag, for example `v6.0.0.rc.0`, and the
 generated action implementations move with them.
 
 If the existing generated staging workflow uses a custom single staging

--- a/lib/github_flow_templates/bin/pin-cpflow-github-ref
+++ b/lib/github_flow_templates/bin/pin-cpflow-github-ref
@@ -12,6 +12,7 @@ USAGE = <<~USAGE
   workflow's pinned control-plane-flow checkout and setup validation ref.
   Regenerate from the cpflow gem when templates changed.
   Use --allow-moving-ref only for short-lived local branch/ref experiments.
+  Use -h or --help to show this help.
 USAGE
 
 if ARGV.include?("--help") || ARGV.include?("-h")

--- a/lib/github_flow_templates/bin/pin-cpflow-github-ref
+++ b/lib/github_flow_templates/bin/pin-cpflow-github-ref
@@ -14,6 +14,11 @@ USAGE = <<~USAGE
   Use --allow-moving-ref only for short-lived local branch/ref experiments.
 USAGE
 
+if ARGV.include?("--help") || ARGV.include?("-h")
+  puts USAGE
+  exit 0
+end
+
 ALLOWED_OPTIONS = ["--allow-moving-ref"].freeze
 FULL_COMMIT_SHA = /\A[0-9a-f]{40}\z/i
 RELEASE_TAG = /\Av\d+\.\d+\.\d+(?:[-.][0-9A-Za-z][0-9A-Za-z.-]*)?\z/

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -523,6 +523,12 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(test_cpflow_flow_path.read).to include("workflow_(ref|sha|repository|file_path)")
     end
 
+    it "prints the pin helper help successfully" do
+      _stdout, _stderr, status = Open3.capture3(pin_cpflow_ref_path.to_s, "--help")
+
+      expect(status).to be_success
+    end
+
     it "rejects a generated workflow whose referenced local action is missing" do
       setup_action = generated_action_path("cpflow-setup-environment")
       FileUtils.mv(setup_action, setup_action.dirname.join("action.yml.missing"))

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -524,9 +524,11 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
     end
 
     it "prints the pin helper help successfully" do
-      _stdout, _stderr, status = Open3.capture3(pin_cpflow_ref_path.to_s, "--help")
+      statuses = %w[-h --help].map do |help_flag|
+        Open3.capture3(pin_cpflow_ref_path.to_s, help_flag).last
+      end
 
-      expect(status).to be_success
+      expect(statuses).to all(be_success)
     end
 
     it "rejects a generated workflow whose referenced local action is missing" do


### PR DESCRIPTION
Tracks #473

## Summary

- handle `-h` and `--help` before argument validation in the generated `bin/pin-cpflow-github-ref` helper
- add a regression spec that executes the generated helper through its public interface
- refresh the generated command reference for the current 6.0.0.rc.0 version
- record the user-visible fix in the changelog

## Before / after

| Scenario | 6.0.0.rc.0 | This PR |
| --- | --- | --- |
| `bin/pin-cpflow-github-ref --help` | exits 1 with `Unknown option(s): --help` | prints usage and exits 0 |
| Repository inspection or mutation during help | argument validation runs | exits before repository inspection or mutation |

## Verification

- `bundle exec rspec spec/command/generate_github_actions_spec.rb spec/command/update_github_actions_spec.rb spec/github_actions_dependency_policy_spec.rb` — 124 examples, 0 failures
- `RUBOCOP_OPTS='--ignore-parent-exclusion' bundle exec rubocop lib/github_flow_templates/bin/pin-cpflow-github-ref spec/command/generate_github_actions_spec.rb` — no offenses
- `.agents/bin/docs` — pass
- `git diff --check origin/main...HEAD` — pass
- `.agents/bin/validate` — local full integration suite could not run because this fresh checkout has no test Control Plane org; failures consistently reported `No org provided`. The focused generator suite above is green, and hosted CI remains required.

<details>
<summary>Regression verification</summary>

```sh
git checkout origin/main -- lib/github_flow_templates/bin/pin-cpflow-github-ref
bundle exec rspec spec/command/generate_github_actions_spec.rb:526
# Fails because the generated helper exits 1 for --help.

git checkout HEAD -- lib/github_flow_templates/bin/pin-cpflow-github-ref
bundle exec rspec spec/command/generate_github_actions_spec.rb:526
# Passes.
```

</details>

## Scope

This fixes the concrete help-contract regression. Issue #473 continues to track the broader downstream workflow-activation, customization-preservation, and security-policy migration findings before 6.0 final.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `pin-cpflow-github-ref` command now supports `-h` and `--help`, displaying usage information and exiting successfully.

- **Documentation**
  - Updated the documented upstream release tag example for `update-github-actions` to `v6.0.0.rc.0`.
  - Added an unreleased changelog entry for the new help behavior.

- **Tests**
  - Added coverage verifying that the command’s help option completes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->