### PR TITLE
Fix build image spawn spec for safe argv

### DIFF
--- a/spec/command/build_image_spec.rb
+++ b/spec/command/build_image_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "shellwords"
 
 describe Command::BuildImage do
   context "when Docker is not running" do
@@ -68,18 +67,27 @@ describe Command::BuildImage do
     end
 
     it "passes additional options to `docker build`", :slow do
-      docker_build_with_test_arg = satisfy do |command|
-        tokens = Shellwords.split(command)
-
-        tokens.first(2) == %w[docker build] && tokens.each_cons(2).include?(["--build-arg", "TEST=123"])
+      spawn_calls = []
+      allow(Process).to receive(:spawn).and_wrap_original do |original, *argv, **spawn_options|
+        spawn_calls << [argv, spawn_options]
+        original.call(*argv, **spawn_options)
       end
-
-      allow(Process).to receive(:spawn).with(docker_build_with_test_arg).and_call_original
-      allow(Process).to receive(:spawn).with(include("docker push")).and_call_original
 
       result = run_cpflow_command("build-image", "-a", app, "--build-arg", "TEST=123")
 
-      expect(Process).to have_received(:spawn).twice
+      docker_build_calls = spawn_calls.select { |argv, _spawn_options| argv.first(2) == %w[docker build] }
+      docker_push_calls = spawn_calls.select { |argv, _spawn_options| argv.first(2) == %w[docker push] }
+
+      expect(spawn_calls.size).to eq(2)
+      expect(docker_build_calls.size).to eq(1)
+      expect(docker_push_calls.size).to eq(1)
+      docker_build_argv, docker_build_spawn_options = docker_build_calls.first
+      docker_push_argv, docker_push_spawn_options = docker_push_calls.first
+
+      expect(docker_build_argv.each_cons(2)).to include(["--build-arg", "TEST=123"])
+      expect(docker_build_spawn_options).to eq(out: File::NULL, err: File::NULL)
+      expect(docker_push_argv).to start_with("docker", "push")
+      expect(docker_push_spawn_options).to eq(out: File::NULL, err: File::NULL)
       expect(result[:status]).to eq(0)
       expect(result[:stderr]).to match(%r{Pushed image to '/org/.+?/image/#{app}:1'})
     end


### PR DESCRIPTION
## Summary

Update the slow `build-image` example to observe `Process.spawn` calls in their current safe-argv form. The spec now verifies one Docker build and one Docker push, adjacent `--build-arg` / `TEST=123` tokens, the expected null-output spawn options, command success, and pushed-image output.

This is useful because PR #413 intentionally replaced shell command strings with separate argv values. The next scheduled Slow run exposed that the old test double still required a single string and rejected the safe call before Docker ran. Production behavior is unchanged here; this PR repairs that stale test harness.

## Related issue

Closes #409.

Issue #409 remained open until natural scheduled Slow run 34093984365 succeeded on merged `main`; that post-merge gate is now complete.

## Validation

- `CI=true CPLN_ORG=shakacode-heroku-to-control-plane-ci SPEC_OPTS='--tag ~slow' .agents/bin/validate` — 977 examples, 0 failures; 220 files inspected by RuboCop, no offenses
- `.agents/bin/docs` — generated command docs are current
- `git diff --check origin/main...HEAD` and `git show --check HEAD` — clean
- Independent exact-head task review — clean; task-review reducer returned `task_complete`
- `codex review --base origin/main` — clean
- Hosted PR checks — 9 successful, 2 expected skips, 0 failures or pending checks
- Isolated exact-head Slow proof — [RSpec Specific run 34079168200](https://github.com/shakacode/control-plane-flow/actions/runs/34079168200), 82 examples, 0 failures, seed 37039

## Checklist

- [x] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
- [x] The change is focused and contains no unrelated cleanup or generated churn.
- [x] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
- [x] I reviewed and understand all submitted content, including AI-assisted changes.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: d73a1f13649f3d1da74ccb76629583a848496d3e
tested_at: exact PR head d73a1f13649f3d1da74ccb76629583a848496d3e
scope: issue #409; spec/command/build_image_spec.rb safe-argv Process.spawn test repair
automated_checks: Fast-filtered .agents/bin/validate 977 examples/0 failures and RuboCop 220 files/no offenses; .agents/bin/docs; git diff --check; git show --check; hosted PR checks 9 successful/2 expected skips/0 failures or pending; exact-head RSpec Specific run 34079168200 passed 82/0 seed 37039; natural scheduled Slow run 34093984365 on merged main passed 82/0 seed 34936; later current-main Fast run 34183729265 passed and the shared org cleared naturally
manual_checks: canonical exact diff; adjacent production Process.spawn and build-image paths; task-review-loop clean; codex autoreview clean; independent completed-batch audit covered PRs 413 and 475
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: no user-visible UI change
paint_check: not applicable: no rendered surface
interaction_change: no
interaction_evidence: not applicable: no UI interaction change
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: test-only change
findings: none
release_blocking: clear
process_gap_disposition: checklist+replay
-->

<details>
<summary>Agent details</summary>

### Audit receipts

<!-- completed-batch-audit-summary:start -->
#### Completed-batch audit

**Status:** Clean — no outstanding findings or follow-ups. [Durable receipt](https://github.com/shakacode/control-plane-flow/pull/475#issuecomment-5578890397).
<!-- completed-batch-audit-summary:end -->

</details>
