### PR TITLE
Close cpflow 6 migration guidance and SSH cleanup gaps

### DIFF
--- a/.github/actions/cpflow-build-docker-image/action.yml
+++ b/.github/actions/cpflow-build-docker-image/action.yml
@@ -57,14 +57,18 @@ runs:
           exit 1
         fi
 
+        known_hosts_backup_ready=false
         known_hosts_replaced=false
         restore_known_hosts_on_prep_failure() {
           status=$?
           if [[ "${status}" -ne 0 ]]; then
-            if [[ -f "${known_hosts_backup}" ]]; then
+            if [[ "${known_hosts_backup_ready}" == "true" ]]; then
               mv -f -- "${known_hosts_backup}" "${HOME}/.ssh/known_hosts"
-            elif [[ "${known_hosts_replaced}" == "true" ]]; then
-              rm -f "${HOME}/.ssh/known_hosts"
+            else
+              rm -f "${known_hosts_backup}"
+              if [[ "${known_hosts_replaced}" == "true" ]]; then
+                rm -f "${HOME}/.ssh/known_hosts"
+              fi
             fi
           fi
           exit "${status}"
@@ -81,6 +85,7 @@ runs:
             exit 1
           fi
           cp -p -- "${HOME}/.ssh/known_hosts" "${known_hosts_backup}"
+          known_hosts_backup_ready=true
         fi
 
         known_hosts_replaced=true

--- a/.github/actions/cpflow-build-docker-image/action.yml
+++ b/.github/actions/cpflow-build-docker-image/action.yml
@@ -52,7 +52,25 @@ runs:
         chmod 700 ~/.ssh
 
         known_hosts_backup="${HOME}/.ssh/cpflow_known_hosts_backup"
-        rm -f "${known_hosts_backup}"
+        if [[ -e "${known_hosts_backup}" ]]; then
+          echo "Refusing to replace SSH known_hosts while a prior cpflow backup exists." >&2
+          exit 1
+        fi
+
+        known_hosts_replaced=false
+        restore_known_hosts_on_prep_failure() {
+          status=$?
+          if [[ "${status}" -ne 0 ]]; then
+            if [[ -f "${known_hosts_backup}" ]]; then
+              mv -f -- "${known_hosts_backup}" "${HOME}/.ssh/known_hosts"
+            elif [[ "${known_hosts_replaced}" == "true" ]]; then
+              rm -f "${HOME}/.ssh/known_hosts"
+            fi
+          fi
+          exit "${status}"
+        }
+        trap restore_known_hosts_on_prep_failure EXIT
+
         if [[ -L "${HOME}/.ssh/known_hosts" ]]; then
           echo "Refusing to replace symlinked SSH known_hosts." >&2
           exit 1
@@ -65,6 +83,7 @@ runs:
           cp -p -- "${HOME}/.ssh/known_hosts" "${known_hosts_backup}"
         fi
 
+        known_hosts_replaced=true
         if [[ -n "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" ]]; then
           printf '%s\n' "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
         else
@@ -95,6 +114,9 @@ runs:
         docker_build_args=()
         ssh_agent_started=false
         build_ssh_prepped=false
+        if [[ -f "${HOME}/.ssh/cpflow_build_key" ]]; then
+          build_ssh_prepped=true
+        fi
 
         cleanup_build_ssh() {
           if [[ "${ssh_agent_started}" == "true" ]]; then
@@ -133,10 +155,7 @@ runs:
           done <<< "${DOCKER_BUILD_EXTRA_ARGS}"
         fi
 
-        if [[ -f "${HOME}/.ssh/cpflow_build_key" ]]; then
-          # Mark prep-step ownership so cleanup_build_ssh restores or removes only
-          # the known_hosts file prepared by this action (see trap above).
-          build_ssh_prepped=true
+        if [[ "${build_ssh_prepped}" == "true" ]]; then
           eval "$(ssh-agent -s)"
           ssh_agent_started=true
           ssh-add "${HOME}/.ssh/cpflow_build_key"

--- a/.github/actions/cpflow-build-docker-image/action.yml
+++ b/.github/actions/cpflow-build-docker-image/action.yml
@@ -51,6 +51,20 @@ runs:
         mkdir -p ~/.ssh
         chmod 700 ~/.ssh
 
+        known_hosts_backup="${HOME}/.ssh/cpflow_known_hosts_backup"
+        rm -f "${known_hosts_backup}"
+        if [[ -L "${HOME}/.ssh/known_hosts" ]]; then
+          echo "Refusing to replace symlinked SSH known_hosts." >&2
+          exit 1
+        fi
+        if [[ -e "${HOME}/.ssh/known_hosts" ]]; then
+          if [[ ! -f "${HOME}/.ssh/known_hosts" ]]; then
+            echo "Refusing to replace non-file SSH known_hosts." >&2
+            exit 1
+          fi
+          cp -p -- "${HOME}/.ssh/known_hosts" "${known_hosts_backup}"
+        fi
+
         if [[ -n "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" ]]; then
           printf '%s\n' "${DOCKER_BUILD_SSH_KNOWN_HOSTS}" > ~/.ssh/known_hosts
         else
@@ -87,11 +101,14 @@ runs:
             ssh-agent -k >/dev/null || true
           fi
           rm -f "${HOME}/.ssh/cpflow_build_key"
-          # Only remove known_hosts if this action's prep step wrote it. On self-hosted
-          # or reused runners we must not touch a user-managed file we did not create,
-          # so the flag is set inside the same prep-detection branch below.
+          # Restore a pre-existing known_hosts file on reused runners. When there was
+          # no original file, remove only the file created by this action.
           if [[ "${build_ssh_prepped}" == "true" ]]; then
-            rm -f "${HOME}/.ssh/known_hosts"
+            if [[ -f "${HOME}/.ssh/cpflow_known_hosts_backup" ]]; then
+              mv -f -- "${HOME}/.ssh/cpflow_known_hosts_backup" "${HOME}/.ssh/known_hosts"
+            else
+              rm -f "${HOME}/.ssh/known_hosts"
+            fi
           fi
         }
         trap cleanup_build_ssh EXIT
@@ -117,8 +134,8 @@ runs:
         fi
 
         if [[ -f "${HOME}/.ssh/cpflow_build_key" ]]; then
-          # Mark prep-step ownership so cleanup_build_ssh only removes known_hosts
-          # when this action wrote it (see trap above).
+          # Mark prep-step ownership so cleanup_build_ssh restores or removes only
+          # the known_hosts file prepared by this action (see trap above).
           build_ssh_prepped=true
           eval "$(ssh-agent -s)"
           ssh_agent_started=true

--- a/.github/actions/cpflow-build-docker-image/action.yml
+++ b/.github/actions/cpflow-build-docker-image/action.yml
@@ -53,7 +53,8 @@ runs:
 
         known_hosts_backup="${HOME}/.ssh/cpflow_known_hosts_backup"
         if [[ -e "${known_hosts_backup}" ]]; then
-          echo "Refusing to replace SSH known_hosts while a prior cpflow backup exists." >&2
+          echo "Refusing to replace SSH known_hosts: a prior cpflow backup exists at ${known_hosts_backup}." >&2
+          echo "If no build is currently running on this runner, restore or remove that backup, then retry." >&2
           exit 1
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ In addition to the standard keepachangelog.com categories, this project uses a l
 
 ### Fixed
 
+- **Preserved an existing SSH `known_hosts` file in the generated Docker-build action, including when setup fails before or after replacement.** The action now restores the original file on success and failure, removes only files it created, and rejects stale backup state rather than overwriting trusted host keys. [PR 477](https://github.com/shakacode/control-plane-flow/pull/477) by [Justin Gordon](https://github.com/justin808). Fixes [issue 473](https://github.com/shakacode/control-plane-flow/issues/473).
 - **Made `update-github-actions` preserve downstream workflows by default and require explicit `--workflows` selection to add or replace them.** Ambiguous staging configuration and differing legacy validators fail before writes. Downstream checks can use the preserved `bin/test-cpflow-github-flow-custom` extension. SHA pins now require a reviewed `--version` label, and the migration guide documents generated action allowlists. Fixes [issue 473](https://github.com/shakacode/control-plane-flow/issues/473).
 - **Fixed the generated `bin/pin-cpflow-github-ref` helper so `-h` and `--help` print usage and exit successfully before inspecting repository state.** Fixes [issue 473](https://github.com/shakacode/control-plane-flow/issues/473).
 

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -132,18 +132,21 @@ production org, using production-only secrets and values.
 
 ## Version Locking
 
-Generated wrappers pin Control Plane Flow with a release tag, for example
-`__CPFLOW_GITHUB_ACTIONS_REF__`. Reusable review-app, staging, cleanup, and
-helper workflows pin the tag in their `uses:` ref. Production promotion pins
-the same tag in the `Checkout control-plane-flow actions` step so the
+Freshly generated wrappers start with a Control Plane Flow release tag, for
+example `__CPFLOW_GITHUB_ACTIONS_REF__`. Before review and merge, use the pin
+helper below to replace that tag with its immutable commit SHA and retain the
+reviewed tag in a readable comment. Reusable review-app, staging, cleanup, and
+helper workflows then use that SHA. Production promotion uses the same SHA and
+tag in the `Checkout control-plane-flow actions` step so the
 caller-owned job can keep `environment: production` and receive production
 environment secrets directly.
 
 Leave `CPFLOW_VERSION` unset so the workflow builds cpflow from the same
 checked-out upstream source. If you set `CPFLOW_VERSION`, it must match the
 release tag your wrappers are pinned to: a `CPFLOW_VERSION=__CPFLOW_MINOR_SERIES__` runtime
-override goes with a wrapper pinned to `uses: ...@v__CPFLOW_MINOR_SERIES__` (substitute the
-release you pinned above).
+override must select the same release as the wrapper source, whether the
+wrapper still uses its initial release tag or an immutable SHA annotated with
+that tag (substitute the release you pinned above).
 
 After updating the `cpflow` gem in this repo, refresh the generated local
 actions and validation helpers in the same PR. The default command

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -176,6 +176,14 @@ pin and validate the complete flow. A differing legacy validator must first
 move its downstream checks to executable
 `bin/test-cpflow-github-flow-custom`.
 
+For a reviewed release, resolve its tag to the exact commit SHA, then pin and
+validate that immutable source:
+
+```sh
+bin/pin-cpflow-github-ref --version vX.Y.Z <40-character-control-plane-flow-commit-sha>
+bin/test-cpflow-github-flow
+```
+
 Do not leave downstream apps pinned to a moving branch such as `main`. For a
 short-lived test of an unreleased upstream PR, pin to a full 40-character commit
 SHA and leave `CPFLOW_VERSION` unset:

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -188,7 +188,8 @@ bin/test-cpflow-github-flow
 
 Do not leave downstream apps pinned to a moving branch such as `main`. For a
 short-lived test of an unreleased upstream PR, pin to a full 40-character commit
-SHA and leave `CPFLOW_VERSION` unset:
+SHA, use the upstream source's current in-progress version tag as the readable
+`--version` label, and leave `CPFLOW_VERSION` unset:
 
 ```sh
 bin/pin-cpflow-github-ref --version vX.Y.Z <40-character-control-plane-flow-commit-sha>

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -145,8 +145,10 @@ release tag your wrappers are pinned to: a `CPFLOW_VERSION=__CPFLOW_MINOR_SERIES
 override goes with a wrapper pinned to `uses: ...@v__CPFLOW_MINOR_SERIES__` (substitute the
 release you pinned above).
 
-After updating the `cpflow` gem in this repo, update the generated wrappers in
-the same PR:
+After updating the `cpflow` gem in this repo, refresh the generated local
+actions and validation helpers in the same PR. The default command
+preserves every top-level workflow, including its refs, triggers, permissions, and
+downstream customizations:
 
 ```sh
 cpflow update-github-actions
@@ -160,12 +162,23 @@ bundle exec cpflow update-github-actions
 bin/test-cpflow-github-flow bundle exec cpflow
 ```
 
+Replace workflow wrappers only after explicitly selecting and reviewing them:
+
+```sh
+cpflow update-github-actions --workflows FILE...
+```
+
+Reapply required downstream customizations after a selected replacement, then
+pin and validate the complete flow. A differing legacy validator must first
+move its downstream checks to executable
+`bin/test-cpflow-github-flow-custom`.
+
 Do not leave downstream apps pinned to a moving branch such as `main`. For a
 short-lived test of an unreleased upstream PR, pin to a full 40-character commit
 SHA and leave `CPFLOW_VERSION` unset:
 
 ```sh
-bin/pin-cpflow-github-ref <40-character-control-plane-flow-commit-sha>
+bin/pin-cpflow-github-ref --version vX.Y.Z <40-character-control-plane-flow-commit-sha>
 bin/test-cpflow-github-flow ruby /path/to/control-plane-flow/bin/cpflow
 ```
 

--- a/lib/github_flow_templates/.github/cpflow-help.md
+++ b/lib/github_flow_templates/.github/cpflow-help.md
@@ -142,11 +142,15 @@ caller-owned job can keep `environment: production` and receive production
 environment secrets directly.
 
 Leave `CPFLOW_VERSION` unset so the workflow builds cpflow from the same
-checked-out upstream source. If you set `CPFLOW_VERSION`, it must match the
-release tag your wrappers are pinned to: a `CPFLOW_VERSION=__CPFLOW_MINOR_SERIES__` runtime
-override must select the same release as the wrapper source, whether the
-wrapper still uses its initial release tag or an immutable SHA annotated with
-that tag (substitute the release you pinned above).
+checked-out upstream source. `CPFLOW_VERSION` is supported only while the
+wrapper itself uses an actual release-tag ref; it must match that tag. Keep it
+unset after replacing the wrapper ref with an immutable SHA because the
+checked-out source already determines the runtime version.
+
+If an existing `bin/test-cpflow-github-flow` differs from cpflow's generated
+validator, first preserve its downstream checks in executable
+`bin/test-cpflow-github-flow-custom`, then remove or rename the old generated
+validator before retrying the update.
 
 After updating the `cpflow` gem in this repo, refresh the generated local
 actions and validation helpers in the same PR. The default command
@@ -172,9 +176,7 @@ cpflow update-github-actions --workflows FILE...
 ```
 
 Reapply required downstream customizations after a selected replacement, then
-pin and validate the complete flow. A differing legacy validator must first
-move its downstream checks to executable
-`bin/test-cpflow-github-flow-custom`.
+pin and validate the complete flow.
 
 For a reviewed release, resolve its tag to the exact commit SHA, then pin and
 validate that immutable source:

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -1407,6 +1407,10 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("permission to manage repository environments and secrets")
       expect(help_md).to include("gh secret set CPLN_TOKEN_PRODUCTION --repo OWNER/REPO --env production")
       expect(help_md).to include("gh secret list --repo OWNER/REPO --env production")
+      expect(help_md).to include("preserves every top-level workflow")
+      expect(help_md).to include("update-github-actions --workflows FILE...")
+      expect(help_md).to include("pin-cpflow-github-ref --version vX.Y.Z")
+      expect(help_md).not_to include("update the generated wrappers in")
       expect(help_md).not_to include("control_plane_flow_ref")
     end
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -974,6 +974,38 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       end
     end
 
+    it "does not restore a partial SSH known_hosts backup when copying fails" do
+      action = YAML.safe_load(build_action_path.read)
+      prepare_script = action.fetch("runs").fetch("steps")
+                             .find { |step| step["name"] == "Prepare SSH agent for Docker build" }
+                             .fetch("run")
+
+      Dir.mktmpdir("cpflow-ssh-backup-failure") do |home|
+        ssh_dir = Pathname(home).join(".ssh")
+        ssh_dir.mkpath
+        known_hosts = ssh_dir.join("known_hosts")
+        known_hosts.write("original-host-key\n")
+        fake_bin = Pathname(home).join("bin")
+        fake_bin.mkpath
+        fake_bin.join("cp").write(<<~SH)
+          #!/bin/sh
+          printf 'partial' > "$4"
+          exit 1
+        SH
+        fake_bin.join("cp").chmod(0o755)
+
+        env = {
+          "HOME" => home,
+          "PATH" => "#{fake_bin}:#{ENV.fetch('PATH')}",
+          "DOCKER_BUILD_SSH_KEY" => "test-private-key",
+          "DOCKER_BUILD_SSH_KNOWN_HOSTS" => "replacement-host-key"
+        }
+        expect(Open3.capture3(env, "bash", "-c", prepare_script).last).not_to be_success
+        expect(known_hosts.read).to eq("original-host-key\n")
+        expect(ssh_dir.join("cpflow_known_hosts_backup")).not_to exist
+      end
+    end
+
     it "wires Docker build inputs through the review-app workflow" do
       contents = reusable_review_app_workflow_path.read
       expect(contents).to include("docker_build_extra_args: ${{ vars.DOCKER_BUILD_EXTRA_ARGS }}")
@@ -1468,6 +1500,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
 
     it "pins the +review-app-* commands in the long-form help markdown" do
       help_md = playground.join(".github/cpflow-help.md").read
+      normalized_help = help_md.gsub(/\s+/, " ")
 
       expect(help_md).to include("`+review-app-deploy`")
       expect(help_md).to include("`+review-app-delete`")
@@ -1505,6 +1538,9 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("For a reviewed release, resolve its tag to the exact commit SHA")
       expect(help_md).to include("Freshly generated wrappers start with a Control Plane Flow release tag")
       expect(help_md).to include("replace that tag with its immutable commit SHA")
+      expect(help_md).to include("must match that tag")
+      expect(normalized_help).to include("Keep it unset after replacing the wrapper ref with an immutable SHA")
+      expect(normalized_help).to include("then remove or rename the old generated validator")
       expect(help_md).not_to include("pin the tag in their `uses:` ref")
       expect(help_md).not_to include("update the generated wrappers in")
       expect(help_md).not_to include("control_plane_flow_ref")
@@ -1537,14 +1573,14 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("DOCKER_BUILD_SSH_KNOWN_HOSTS")
     end
 
-    # Issue #341: the version-locking example must not emit a concrete release number.
-    # A literal version (e.g. 5.0.1) goes stale against the @v#{VERSION} wrapper refs in
-    # the same generated file and reads like a required old runtime override.
-    it "uses a placeholder version in the CPFLOW_VERSION example" do
+    # Issue #341: version-locking guidance must not suggest a stale concrete runtime
+    # override, and SHA-pinned wrappers must leave CPFLOW_VERSION unset.
+    it "limits CPFLOW_VERSION to release-tag wrapper refs" do
       help_md = playground.join(".github/cpflow-help.md").read
+      normalized_help = help_md.gsub(/\s+/, " ")
 
-      expect(help_md).to match(/CPFLOW_VERSION=\d+\.\d+\.x\b/)
-      expect(help_md).to match(/wrapper still uses its initial release tag or an immutable SHA annotated with/)
+      expect(normalized_help).to include("supported only while the wrapper itself uses an actual release-tag ref")
+      expect(normalized_help).to include("Keep it unset after replacing the wrapper ref with an immutable SHA")
       expect(help_md).not_to match(/CPFLOW_VERSION=\d+\.\d+\.\d+/)
     end
 

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -1419,6 +1419,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("preserves every top-level workflow")
       expect(help_md).to include("update-github-actions --workflows FILE...")
       expect(help_md).to include("pin-cpflow-github-ref --version vX.Y.Z")
+      expect(help_md).to include("For a reviewed release, resolve its tag to the exact commit SHA")
       expect(help_md).to include("Freshly generated wrappers start with a Control Plane Flow release tag")
       expect(help_md).to include("replace that tag with its immutable commit SHA")
       expect(help_md).not_to include("pin the tag in their `uses:` ref")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -891,6 +891,89 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       )
     end
 
+    it "restores SSH files when the build exits or fails before starting ssh-agent" do
+      action = YAML.safe_load(build_action_path.read)
+      prepare_script = action.fetch("runs").fetch("steps")
+                             .find { |step| step["name"] == "Prepare SSH agent for Docker build" }
+                             .fetch("run")
+      build_script = action.fetch("runs").fetch("steps").find do |step|
+        step["name"] == "Build Docker image"
+      end.fetch("run")
+
+      [
+        { "DOCKER_BUILD_EXTRA_ARGS" => "--build-arg BAD", "WORKING_DIRECTORY" => ".", "success" => false },
+        { "DOCKER_BUILD_EXTRA_ARGS" => "", "WORKING_DIRECTORY" => "missing-directory", "success" => false },
+        { "DOCKER_BUILD_EXTRA_ARGS" => "", "WORKING_DIRECTORY" => ".", "success" => true }
+      ].each do |scenario|
+        Dir.mktmpdir("cpflow-ssh-cleanup") do |home|
+          ssh_dir = Pathname(home).join(".ssh")
+          ssh_dir.mkpath
+          known_hosts = ssh_dir.join("known_hosts")
+          known_hosts.write("original-host-key\n")
+          fake_bin = Pathname(home).join("bin")
+          fake_bin.mkpath
+          %w[cpflow ssh-add].each do |command|
+            fake_bin.join(command).write("#!/bin/sh\nexit 0\n")
+            fake_bin.join(command).chmod(0o755)
+          end
+          fake_bin.join("ssh-agent").write(<<~SH)
+            #!/bin/sh
+            if [ "${1:-}" = "-s" ]; then
+              echo 'SSH_AGENT_PID=123; export SSH_AGENT_PID;'
+            fi
+            exit 0
+          SH
+          fake_bin.join("ssh-agent").chmod(0o755)
+
+          prepare_env = {
+            "HOME" => home,
+            "DOCKER_BUILD_SSH_KEY" => "test-private-key",
+            "DOCKER_BUILD_SSH_KNOWN_HOSTS" => "replacement-host-key"
+          }
+          expect(Open3.capture3(prepare_env, "bash", "-c", prepare_script).last).to be_success
+
+          build_env = {
+            "HOME" => home,
+            "APP_NAME" => "test-app",
+            "COMMIT_SHA" => "a" * 40,
+            "CONTROL_PLANE_ORG" => "test-org",
+            "PR_NUMBER" => "",
+            "PATH" => "#{fake_bin}:#{ENV.fetch('PATH')}",
+            **scenario.except("success")
+          }
+          status = Open3.capture3(build_env, "bash", "-c", build_script).last
+          expect(status.success?).to eq(scenario.fetch("success"))
+          expect(known_hosts.read).to eq("original-host-key\n")
+          expect(ssh_dir.join("cpflow_known_hosts_backup")).not_to exist
+          expect(ssh_dir.join("cpflow_build_key")).not_to exist
+        end
+      end
+    end
+
+    it "restores SSH known_hosts when preparation fails after replacement" do
+      action = YAML.safe_load(build_action_path.read)
+      prepare_script = action.fetch("runs").fetch("steps")
+                             .find { |step| step["name"] == "Prepare SSH agent for Docker build" }
+                             .fetch("run")
+
+      Dir.mktmpdir("cpflow-ssh-prep-failure") do |home|
+        ssh_dir = Pathname(home).join(".ssh")
+        ssh_dir.mkpath
+        known_hosts = ssh_dir.join("known_hosts")
+        known_hosts.write("original-host-key\n")
+        ssh_dir.join("cpflow_build_key").mkpath
+
+        env = {
+          "HOME" => home,
+          "DOCKER_BUILD_SSH_KEY" => "test-private-key",
+          "DOCKER_BUILD_SSH_KNOWN_HOSTS" => "replacement-host-key"
+        }
+        expect(Open3.capture3(env, "bash", "-c", prepare_script).last).not_to be_success
+        expect(known_hosts.read).to eq("original-host-key\n")
+        expect(ssh_dir.join("cpflow_known_hosts_backup")).not_to exist
+      end
+    end
+
     it "wires Docker build inputs through the review-app workflow" do
       contents = reusable_review_app_workflow_path.read
       expect(contents).to include("docker_build_extra_args: ${{ vars.DOCKER_BUILD_EXTRA_ARGS }}")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -882,6 +882,15 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(contents).to include("github.com ssh-ed25519")
     end
 
+    it "preserves and restores a pre-existing SSH known_hosts file" do
+      contents = build_action_path.read
+      expect(contents).to include('cp -p -- "${HOME}/.ssh/known_hosts" "${known_hosts_backup}"')
+      expect(contents).to include("Refusing to replace symlinked SSH known_hosts.")
+      expect(contents).to include(
+        'mv -f -- "${HOME}/.ssh/cpflow_known_hosts_backup" "${HOME}/.ssh/known_hosts"'
+      )
+    end
+
     it "wires Docker build inputs through the review-app workflow" do
       contents = reusable_review_app_workflow_path.read
       expect(contents).to include("docker_build_extra_args: ${{ vars.DOCKER_BUILD_EXTRA_ARGS }}")

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -886,6 +886,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       contents = build_action_path.read
       expect(contents).to include('cp -p -- "${HOME}/.ssh/known_hosts" "${known_hosts_backup}"')
       expect(contents).to include("Refusing to replace symlinked SSH known_hosts.")
+      expect(contents).to include("If no build is currently running on this runner, restore or remove that backup")
       expect(contents).to include(
         'mv -f -- "${HOME}/.ssh/cpflow_known_hosts_backup" "${HOME}/.ssh/known_hosts"'
       )

--- a/spec/command/generate_github_actions_spec.rb
+++ b/spec/command/generate_github_actions_spec.rb
@@ -1410,6 +1410,9 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       expect(help_md).to include("preserves every top-level workflow")
       expect(help_md).to include("update-github-actions --workflows FILE...")
       expect(help_md).to include("pin-cpflow-github-ref --version vX.Y.Z")
+      expect(help_md).to include("Freshly generated wrappers start with a Control Plane Flow release tag")
+      expect(help_md).to include("replace that tag with its immutable commit SHA")
+      expect(help_md).not_to include("pin the tag in their `uses:` ref")
       expect(help_md).not_to include("update the generated wrappers in")
       expect(help_md).not_to include("control_plane_flow_ref")
     end
@@ -1448,7 +1451,7 @@ describe Command::GenerateGithubActions, :enable_validations, :without_config_fi
       help_md = playground.join(".github/cpflow-help.md").read
 
       expect(help_md).to match(/CPFLOW_VERSION=\d+\.\d+\.x\b/)
-      expect(help_md).to match(/uses: \.\.\.@v\d+\.\d+\.x\b/)
+      expect(help_md).to match(/wrapper still uses its initial release tag or an immutable SHA annotated with/)
       expect(help_md).not_to match(/CPFLOW_VERSION=\d+\.\d+\.\d+/)
     end
 


### PR DESCRIPTION
## Summary

Correct the generated cpflow help so downstream maintainers get the safe v6 update contract discovered while exercising #473 in HiChee.

- state that the default updater preserves top-level workflows;
- document explicit `--workflows FILE...` replacement and required downstream reapplication;
- show the pin helper's mandatory `--version` argument; and
- preserve and restore an existing SSH `known_hosts` file when the generated Docker-build action runs on a reused runner, fail safely on partial backup creation, and provide recovery guidance for an interrupted prior run;
- add focused generator assertions to prevent these regressions from returning.

Follow-up to #473 and #476.

## Verification

- Red/green focused specs: the new assertions failed against the old behavior, then `bundle exec rspec spec/command/generate_github_actions_spec.rb` passed (100 examples, 0 failures).
- `bundle exec rake check_command_docs` passed.
- `bundle exec rubocop --no-server --config .rubocop.yml` passed (220 files).
- `git diff --check` passed.
- Parsed embedded shell syntax for the changed composite action passed `bash -n`.
- Independent adversarial/security review, ShellCheck, the trusted GitHub Actions scanner, and strict actor/file preflight passed at the exact current head.
- The full integration suite was attempted but its Control Plane-dependent examples failed because no test org was configured; the affected generator suite is green and hosted CI owns the configured environment.

No UI, application runtime, database, or release artifact is changed.
