### PR TITLE
Wait for PostgreSQL readiness before dummy app hooks

### DIFF
--- a/spec/command/dummy_entrypoint_spec.rb
+++ b/spec/command/dummy_entrypoint_spec.rb
@@ -20,21 +20,34 @@ RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
   end
 
   before do
+    # Exercise Bundler setup without loading the repository's unrelated gems.
+    File.write(File.join(directory, "Gemfile"), "")
     # Keep the old TCP probe runnable too, so it fails the readiness assertion.
     %w[grep sed].each { |name| File.symlink("/usr/bin/#{name}", File.join(directory, name)) }
     executable("curl", 'echo "curl: (52) Empty reply from server" >&2; exit 52')
     executable("sleep", 'echo sleep >> "$EVENTS"')
-    executable("pg_isready", <<~'SH')
+    executable("ruby", <<~'SH')
       printf '%s\n' "$@" >> "$PROBE_ARGS"
-      count=0
-      if [ -f "$COUNT" ]; then read -r count < "$COUNT"; fi
-      count=$((count + 1))
-      echo "$count" > "$COUNT"
-      echo probe >> "$EVENTS"
-      if [ "$count" -ge "$READY_AFTER" ]; then exit 0; fi
-      echo "connection failed: $DATABASE_URL" >&2
-      exit "$PROBE_STATUS"
+      exec "$REAL_RUBY" "$@"
     SH
+    File.write(File.join(directory, "pg.rb"), <<~'RUBY')
+      require "json"
+      module PG
+        class Connection
+          def self.ping(url, **options)
+            File.open(ENV.fetch("PING_ARGS"), "a") { |file| file.puts JSON.generate([url, options]) }
+            count_file = ENV.fetch("COUNT")
+            count = (File.exist?(count_file) ? File.read(count_file).to_i : 0) + 1
+            File.write(count_file, count)
+            File.open(ENV.fetch("EVENTS"), "a") { |file| file.puts "probe" }
+            return 0 if count >= ENV.fetch("READY_AFTER").to_i
+
+            warn "connection failed: #{url}"
+            ENV.fetch("PROBE_STATUS").to_i
+          end
+        end
+      end
+    RUBY
     executable("hook", <<~'SH')
       echo hook >> "$EVENTS"
       printf '<%s>\n' "$@"
@@ -43,9 +56,10 @@ RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
   end
 
   def run_entrypoint(ready_after: 3, hook_status: 0, probe_status: 2, missing_probe: false)
-    File.unlink(File.join(directory, "pg_isready")) if missing_probe
+    File.unlink(File.join(directory, "ruby")) if missing_probe
     environment = {
-      "PATH" => directory, "DATABASE_URL" => database_url,
+      "PATH" => directory, "DATABASE_URL" => database_url, "BUNDLE_GEMFILE" => File.join(directory, "Gemfile"),
+      "REAL_RUBY" => RbConfig.ruby, "RUBYLIB" => directory, "PING_ARGS" => File.join(directory, "ping-args"),
       "EVENTS" => File.join(directory, "events"), "COUNT" => File.join(directory, "count"),
       "PROBE_ARGS" => File.join(directory, "probe-args"), "READY_AFTER" => ready_after.to_s,
       "HOOK_STATUS" => hook_status.to_s, "PROBE_STATUS" => probe_status.to_s
@@ -62,8 +76,8 @@ RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
       .to eq(%w[probe sleep probe sleep probe hook])
     expect(stdout).to include("<argument with spaces>\n<*>\n")
     expect(stdout + stderr).not_to include("secret-password")
-    expect(File.readlines(File.join(directory, "probe-args"), chomp: true))
-      .to eq(["-q", "-t", "3", "-d", database_url] * 3)
+    expect(File.readlines(File.join(directory, "ping-args"), chomp: true).map { |line| JSON.parse(line) })
+      .to eq([[database_url, { "connect_timeout" => 3 }]] * 3)
   end
 
   it "retries a server rejecting connections and propagates an invalid hook's failure without retrying it" do
@@ -71,6 +85,14 @@ RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
 
     expect(status.exitstatus).to eq(64)
     expect(File.readlines(File.join(directory, "events"), chomp: true)).to eq(%w[probe sleep probe hook])
+  end
+
+  it "keeps database credentials out of the readiness process arguments" do
+    stdout, stderr, status = run_entrypoint(ready_after: 1)
+
+    expect(status).to be_success
+    expect(File.read(File.join(directory, "probe-args"))).not_to include("secret-password")
+    expect(stdout + stderr).not_to include("secret-password")
   end
 
   it "fails after bounded probes without executing the hook or exposing credentials" do
@@ -86,16 +108,26 @@ RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
     stdout, stderr, status = run_entrypoint(probe_status: 3)
 
     expect(status.exitstatus).to eq(1)
-    expect(stderr).to include("check DATABASE_URL and pg_isready")
+    expect(stderr).to include("check DATABASE_URL and the Ruby pg gem")
     expect(stdout + stderr).not_to include("secret-password")
     expect(File.readlines(File.join(directory, "events"), chomp: true)).to eq(["probe"])
   end
 
-  it "fails with installation guidance when the PostgreSQL client is missing" do
+  it "fails with installation guidance when Ruby is missing" do
     _stdout, stderr, status = run_entrypoint(missing_probe: true)
 
     expect(status.exitstatus).to eq(1)
-    expect(stderr).to include("install postgresql-client")
+    expect(stderr).to include("Ruby and the pg gem are required")
+    expect(File.exist?(File.join(directory, "events"))).to be(false)
+  end
+
+  it "fails without retrying or leaking credentials when the pg gem cannot load" do
+    File.write(File.join(directory, "pg.rb"), 'raise LoadError, ENV.fetch("DATABASE_URL")')
+    stdout, stderr, status = run_entrypoint
+
+    expect(status.exitstatus).to eq(1)
+    expect(stderr).to include("check DATABASE_URL and the Ruby pg gem")
+    expect(stdout + stderr).not_to include("secret-password")
     expect(File.exist?(File.join(directory, "events"))).to be(false)
   end
 

--- a/spec/command/dummy_entrypoint_spec.rb
+++ b/spec/command/dummy_entrypoint_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "open3"
+require "tmpdir"
+
+RSpec.describe "Dummy app entrypoint" do # rubocop:disable RSpec/DescribeClass
+  let(:entrypoint) { File.expand_path("../dummy/.controlplane/entrypoint.sh", __dir__) }
+  let(:database_url) { "postgresql://postgres:secret-password@postgres:5432/not_created_yet" }
+
+  let(:directory) { Dir.mktmpdir("dummy-entrypoint") }
+
+  after { FileUtils.remove_entry(directory) }
+
+  def executable(name, body)
+    path = File.join(directory, name)
+    File.write(path, "#!/bin/sh\n#{body}\n")
+    File.chmod(0o755, path)
+    path
+  end
+
+  before do
+    # Keep the old TCP probe runnable too, so it fails the readiness assertion.
+    %w[grep sed].each { |name| File.symlink("/usr/bin/#{name}", File.join(directory, name)) }
+    executable("curl", 'echo "curl: (52) Empty reply from server" >&2; exit 52')
+    executable("sleep", 'echo sleep >> "$EVENTS"')
+    executable("pg_isready", <<~'SH')
+      printf '%s\n' "$@" >> "$PROBE_ARGS"
+      count=0
+      if [ -f "$COUNT" ]; then read -r count < "$COUNT"; fi
+      count=$((count + 1))
+      echo "$count" > "$COUNT"
+      echo probe >> "$EVENTS"
+      if [ "$count" -ge "$READY_AFTER" ]; then exit 0; fi
+      echo "connection failed: $DATABASE_URL" >&2
+      exit "$PROBE_STATUS"
+    SH
+    executable("hook", <<~'SH')
+      echo hook >> "$EVENTS"
+      printf '<%s>\n' "$@"
+      exit "$HOOK_STATUS"
+    SH
+  end
+
+  def run_entrypoint(ready_after: 3, hook_status: 0, probe_status: 2, missing_probe: false)
+    File.unlink(File.join(directory, "pg_isready")) if missing_probe
+    environment = {
+      "PATH" => directory, "DATABASE_URL" => database_url,
+      "EVENTS" => File.join(directory, "events"), "COUNT" => File.join(directory, "count"),
+      "PROBE_ARGS" => File.join(directory, "probe-args"), "READY_AFTER" => ready_after.to_s,
+      "HOOK_STATUS" => hook_status.to_s, "PROBE_STATUS" => probe_status.to_s
+    }
+    Open3.capture3(environment, "/bin/sh", entrypoint, File.join(directory, "hook"),
+                   "argument with spaces", "*", unsetenv_others: true)
+  end
+
+  it "waits for PostgreSQL instead of starting the hook after an empty TCP reply" do
+    stdout, stderr, status = run_entrypoint
+
+    expect(status).to be_success
+    expect(File.readlines(File.join(directory, "events"), chomp: true))
+      .to eq(%w[probe sleep probe sleep probe hook])
+    expect(stdout).to include("<argument with spaces>\n<*>\n")
+    expect(stdout + stderr).not_to include("secret-password")
+    expect(File.readlines(File.join(directory, "probe-args"), chomp: true))
+      .to eq(["-q", "-t", "3", "-d", database_url] * 3)
+  end
+
+  it "retries a server rejecting connections and propagates an invalid hook's failure without retrying it" do
+    _stdout, _stderr, status = run_entrypoint(ready_after: 2, probe_status: 1, hook_status: 64)
+
+    expect(status.exitstatus).to eq(64)
+    expect(File.readlines(File.join(directory, "events"), chomp: true)).to eq(%w[probe sleep probe hook])
+  end
+
+  it "fails after bounded probes without executing the hook or exposing credentials" do
+    stdout, stderr, status = run_entrypoint(ready_after: 100)
+
+    expect(status.exitstatus).to eq(1)
+    expect(stderr).to include("PostgreSQL did not become ready after 60 attempts")
+    expect(stdout + stderr).not_to include("secret-password")
+    expect(File.readlines(File.join(directory, "events"), chomp: true)).to eq((%w[probe sleep] * 59) + ["probe"])
+  end
+
+  it "fails immediately for an invalid readiness configuration without exposing credentials" do
+    stdout, stderr, status = run_entrypoint(probe_status: 3)
+
+    expect(status.exitstatus).to eq(1)
+    expect(stderr).to include("check DATABASE_URL and pg_isready")
+    expect(stdout + stderr).not_to include("secret-password")
+    expect(File.readlines(File.join(directory, "events"), chomp: true)).to eq(["probe"])
+  end
+
+  it "fails with installation guidance when the PostgreSQL client is missing" do
+    _stdout, stderr, status = run_entrypoint(missing_probe: true)
+
+    expect(status.exitstatus).to eq(1)
+    expect(stderr).to include("install postgresql-client")
+    expect(File.exist?(File.join(directory, "events"))).to be(false)
+  end
+
+  [nil, ""].each do |url|
+    context "when DATABASE_URL is #{url.inspect}" do
+      let(:database_url) { url }
+
+      it "rejects missing configuration instead of probing a default local database" do
+        _stdout, stderr, status = run_entrypoint(ready_after: 1)
+
+        expect(status.exitstatus).to eq(1)
+        expect(stderr).to include("DATABASE_URL must be set")
+        expect(File.exist?(File.join(directory, "events"))).to be(false)
+      end
+    end
+  end
+end

--- a/spec/dummy/.controlplane/entrypoint.sh
+++ b/spec/dummy/.controlplane/entrypoint.sh
@@ -2,24 +2,45 @@
 
 echo "Starting entrypoint.sh..."
 
-wait_for_service()
-{
-  until curl -I -sS "$1" 2>&1 | grep -q "Empty reply from server"; do
-    echo " - $1 is unavailable, sleeping..."
-    sleep 1
-  done
-
-  echo " - $1 is available"
-}
-
 wait_for_services()
 {
-  echo "Waiting for services..."
+  echo "Waiting for PostgreSQL..."
 
-  wait_for_service "$(printf '%s\n' "$DATABASE_URL" | sed -e 's|^.*@||' -e 's|/.*$||')"
+  if [ -z "$DATABASE_URL" ]; then
+    echo "ERROR: DATABASE_URL must be set before waiting for PostgreSQL." >&2
+    return 1
+  fi
+
+  if ! command -v pg_isready >/dev/null 2>&1; then
+    echo "ERROR: pg_isready is required; install postgresql-client." >&2
+    return 1
+  fi
+
+  # A TCP connection (including an empty proxy reply) does not prove PostgreSQL
+  # is accepting connections. pg_isready also works before db:prepare creates
+  # the application's database. Bound each probe and the overall retry count.
+  attempt=1
+  while [ "$attempt" -le 60 ]; do
+    pg_isready -q -t 3 -d "$DATABASE_URL" >/dev/null 2>&1
+    status=$?
+    case "$status" in
+      0) echo " - PostgreSQL is accepting connections"; return 0 ;;
+      1|2) ;;
+      *) echo "ERROR: PostgreSQL readiness probe failed; check DATABASE_URL and pg_isready." >&2; return 1 ;;
+    esac
+    if [ "$attempt" -eq 60 ]; then
+      break
+    fi
+    echo " - PostgreSQL is unavailable, sleeping..."
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+
+  echo "ERROR: PostgreSQL did not become ready after 60 attempts; check the database workload." >&2
+  return 1
 }
 
-wait_for_services
+wait_for_services || exit 1
 
 # If running the rails server then create or migrate existing database
 # Note: db:prepare is also run in release.sh during deployment. This ensures

--- a/spec/dummy/.controlplane/entrypoint.sh
+++ b/spec/dummy/.controlplane/entrypoint.sh
@@ -11,22 +11,31 @@ wait_for_services()
     return 1
   fi
 
-  if ! command -v pg_isready >/dev/null 2>&1; then
-    echo "ERROR: pg_isready is required; install postgresql-client." >&2
+  if ! command -v ruby >/dev/null 2>&1; then
+    echo "ERROR: Ruby and the pg gem are required for PostgreSQL readiness." >&2
     return 1
   fi
 
   # A TCP connection (including an empty proxy reply) does not prove PostgreSQL
-  # is accepting connections. pg_isready also works before db:prepare creates
-  # the application's database. Bound each probe and the overall retry count.
+  # is accepting connections. The app's pg gem uses the same libpq ping API as
+  # pg_isready, including before db:prepare creates the database. Read the URL
+  # from the existing environment so its credentials never enter process argv.
   attempt=1
   while [ "$attempt" -le 60 ]; do
-    pg_isready -q -t 3 -d "$DATABASE_URL" >/dev/null 2>&1
+    ruby -e '
+      begin
+        require "bundler/setup"
+        require "pg"
+        exit PG::Connection.ping(ENV.fetch("DATABASE_URL"), connect_timeout: 3)
+      rescue LoadError, StandardError
+        exit 3
+      end
+    ' >/dev/null 2>&1
     status=$?
     case "$status" in
       0) echo " - PostgreSQL is accepting connections"; return 0 ;;
       1|2) ;;
-      *) echo "ERROR: PostgreSQL readiness probe failed; check DATABASE_URL and pg_isready." >&2; return 1 ;;
+      *) echo "ERROR: PostgreSQL readiness probe failed; check DATABASE_URL and the Ruby pg gem." >&2; return 1 ;;
     esac
     if [ "$attempt" -eq 60 ]; then
       break


### PR DESCRIPTION
## Summary

Wait for PostgreSQL to accept connections before the dummy app starts its hook. The old HTTP probe treated an empty TCP reply as readiness, so a hook could start before PostgreSQL was available.

This fixture-only change uses the app's existing PostgreSQL Ruby library, reads the connection URL from the environment without exposing it in process arguments, and stops after 60 bounded attempts. It preserves command arguments and hook failures, without retrying migrations or changing production templates.

## Related issue

Addresses #479. Keep the issue open until a natural scheduled Slow run verifies the fix on merged main. Local reproduction proves false readiness, not whether the original remote failure came from PostgreSQL restarting or a network proxy.

## Validation

Nine deterministic regression tests, full shell checks, and Ruby lint pass. Local checks with the actual PostgreSQL gem also verify connection-URL routing, password-free process arguments, hook failure propagation, and loading from a deployment bundle.

Review the readiness loop and its regression spec. Independent final review and fixture QA pass. Current-head hosted Fast, Ruby 3.3/3.4 compatibility, lint, links, docs and Claude review pass. Review findings are resolved; merge still requires explicit approval.

## Checklist

- [x] This PR addresses an accepted issue or maintainer request, or is a small typo fix.
- [x] The change is focused and contains no unrelated cleanup or generated churn.
- [x] I added or updated tests, documentation, and `CHANGELOG.md` where applicable.
- [x] I reviewed and understand all submitted content, including AI-assisted changes.

<details>
<summary>Agent details</summary>

### Commands and results

- PASS `env -u CPLN_TOKEN -u CPLN_ACCESS_TOKEN CPLN_ORG='' SPEC=spec/command/dummy_entrypoint_spec.rb .agents/bin/validate` on clean committed head: full ShellCheck inventory, nine examples / zero failures (seed33034), RuboCop221 files / no offenses.
- PASS canonical base-to-head `git diff --check` and exact-diff byte comparison.
- RED: original empty-TCP-reply implementation starts the hook prematurely. A later synthetic-credential regression also failed against the first published implementation, which exposed the URL in `pg_isready` arguments.
- GREEN: actual Ruby3.2/pg1.5.4 and Ruby3.4/pg1.6.3 local loopback replays exercise full URI query routing, readiness before application database creation, safe process arguments/output, and hook exit64. Isolated deployment-bundle replay proves `bundler/setup` is required and the actual probe works with the nested bundle layout. No image build or external deployment.
- Full credentialed suite not run locally; the focused test-app substitution covers these two fixture paths. The untagged regression spec is included in hosted Fast, not the explicit compatibility-spec list. Natural Slow remains a separate post-merge evidence requirement.

### Exact-head and review evidence

- Base: `fc15e58140bd91cbc9cb9b012e468eca559a9826` (main).
- Head: `6be3d9e1e66d06f282b97ce4767f9598f59c9f87`.
- Diff identity: `5274cb31f91cdbe9f38efa8a391aee2439cad1dcf435b46d6648aecfbf0fc6f6`.
- Two paths only: `spec/dummy/.controlplane/entrypoint.sh` and `spec/command/dummy_entrypoint_spec.rb`.
- The initial seven-test/clean task-review receipt describes the first published head only. Final independent `codex review --base fc15e58140bd91cbc9cb9b012e468eca559a9826` completed with no actionable findings on this committed two-file branch; actual review model gpt-6-astra/high. Independent fixture QA also passes, including actual pg1.5.4 process arguments, URI routing, rejection/status behavior,3.01-second stalled-connection timeout despite a URL override, and nested deployment-bundle loading.

### QA Evidence

- QA lane: existing independent Codex reviewer, branch `jg-codex/479-postgres-readiness`.
- Scope checked: dummy PostgreSQL readiness, credential handling, deployment-bundle loading, and hook forwarding; no production template or workflow change.
- Tested at: base `fc15e58140bd91cbc9cb9b012e468eca559a9826` through head `6be3d9e1e66d06f282b97ce4767f9598f59c9f87`.
- Automated checks: parent committed nine-spec regression, full ShellCheck and RuboCop pass; independent engine nine-spec run (seed30689), full-branch review and affected fixture QA pass.
- Manual checks: local real-client and deployment-bundle replay; original hosted environment not reproduced.
- User-visible UI change: no.
- Visual evidence: not applicable: shell fixture only.
- Interaction change: no; not applicable: no UI interaction.
- Interaction evidence: not applicable: shell fixture only.
- Visual fix: no; not applicable: no visual change.
- Negative control: not applicable: no visual fix; functional red and mutation evidence retained.
- Performance evidence: not applicable: bounded correctness wait, no performance claim.
- Findings: credential-in-argv repair independently verified fixed; no remaining code findings.
- QA required: yes.
- QA required rationale: the fixture is used by the integration test harness; independent behavior and coverage verification is required.
- QA lane status: satisfied.
- Release-blocking status: clear for this fixture QA; no release authority.
- Process-gap disposition: script.

<!-- qa-evidence v2
required: yes
status: satisfied
head_sha: 6be3d9e1e66d06f282b97ce4767f9598f59c9f87
tested_at: base fc15e58140bd91cbc9cb9b012e468eca559a9826 through head 6be3d9e1e66d06f282b97ce4767f9598f59c9f87
scope: dummy PostgreSQL readiness, credential handling, deployment-bundle loading and hook forwarding
automated_checks: parent committed nine regression specs and full ShellCheck/RuboCop pass; independent nine-spec run, full-branch review and actual pg1.5.4 fixture QA pass
manual_checks: local real-client and deployment-bundle replay; original hosted environment not reproduced
user_visible_ui_change: no
visual_evidence_destination: not_applicable
visual_evidence: not applicable: shell fixture only
paint_check: not applicable: no UI change
interaction_change: no
interaction_evidence: not applicable: no UI interaction
visual_fix: no
negative_control: not applicable: no visual fix
performance_impact: not_applicable
performance_evidence: not applicable: correctness wait, no performance claim
findings: credential-in-argv repair independently verified fixed; no remaining code findings
release_blocking: clear
process_gap_disposition: script
-->

<!-- priority-finding-dispositions v1
head_sha: 6be3d9e1e66d06f282b97ce4767f9598f59c9f87
finding: url=https://github.com/shakacode/control-plane-flow/pull/481#discussion_r3966744719 | severity=P2 | disposition=fixed | evidence=https://github.com/shakacode/control-plane-flow/commit/6be3d9e1e66d06f282b97ce4767f9598f59c9f87
-->

### Decision log

- Read the URL inside the existing Ruby pg library, not as a subprocess argument. `bundler/setup` loads the production bundle; native libpq parsing preserves query/host/port semantics without a custom partial URL parser. No dependency added.
- Retain the intentional 60-attempt limit. The [cold-start headroom note](https://github.com/shakacode/control-plane-flow/pull/481#discussion_r3966101381) remains for natural Slow verification in #479. Fast does not prove slowest-environment headroom; this is not a guaranteed four-minute wait.
- [Credential-in-argv finding](https://github.com/shakacode/control-plane-flow/pull/481#discussion_r3966744719) independently confirmed and verified fixed; the regression checks both process arguments and output rather than output alone.
- No changelog entry: test-fixture repair, no user-facing CLI or generated-template change.
- No manual workflow dispatch, merge, deployment, or release. No actual private-credential disclosure was established; the confirmed defect was the argument exposure path.

### Review churn

One confirmed post-publication repair commit. The earlier hosted cohort finished before this candidate, so no overlapping superseded validation run; no old-head test rerun requested. No completed-batch audit or merge authorization is claimed.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application startup checks for PostgreSQL readiness.
  - Startup now retries transient database readiness failures with bounded attempts.
  - Containers stop cleanly when the database cannot become ready or required configuration is missing.
  - Invalid PostgreSQL client status is reported as a fatal startup error.
  - Startup hook failures now propagate correctly.
  - Sensitive database credentials are not exposed during readiness checks.

- **Tests**
  - Added coverage for readiness behavior, retry limits, configuration validation, failure handling, and credential protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

